### PR TITLE
Di Reference definitions

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -235,6 +235,8 @@ class Container implements ContainerInterface
 
         $object = $reflection->newInstanceArgs($dependencies);
 
+        $definition = $this->resolveDependencies($definition);
+
         foreach ($definition as $action => $arguments) {
             if (substr($action, -2) === '()') {
                 // method call

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -10,6 +10,7 @@ use yii\di\InvalidConfigException;
 use yii\di\NotFoundException;
 use yii\di\Reference;
 use yii\di\tests\code\Car;
+use yii\di\tests\code\ColorPink;
 use yii\di\tests\code\ConstructorTestClass;
 use yii\di\tests\code\EngineInterface;
 use yii\di\tests\code\EngineMarkOne;
@@ -181,12 +182,15 @@ class ContainerTest extends TestCase
     {
         $container = new Container([
             'engine' => EngineMarkOne::class,
+            'color' => ColorPink::class,
             'car' => [
                 '__class' => Car::class,
                 '__construct()' => [new Reference('engine')],
+                'color' => new Reference('color')
             ],
         ]);
         $object = $container->get('car');
         $this->assertInstanceOf(Car::class, $object);
+        $this->assertInstanceOf(ColorPink::class, $object->color);
     }
 }

--- a/tests/code/Car.php
+++ b/tests/code/Car.php
@@ -7,6 +7,14 @@ namespace yii\di\tests\code;
  */
 class Car
 {
+    /**
+     * @var ColorInterface
+     */
+    public $color;
+
+    /**
+     * @var EngineInterface
+     */
     private $engine;
 
     /**

--- a/tests/code/ColorInterface.php
+++ b/tests/code/ColorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace yii\di\tests\code;
+
+/**
+ * Interface ColorInterface defines car color
+ *
+ * @package yii\di\tests\code
+ */
+interface ColorInterface
+{
+    /**
+     * @return string
+     */
+    public function getColor(): string;
+}

--- a/tests/code/ColorPink.php
+++ b/tests/code/ColorPink.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace yii\di\tests\code;
+
+/**
+ * Class ColorPink
+ *
+ * @package yii\di\tests\code
+ */
+class ColorPink implements ColorInterface
+{
+    private const COLOR_PINK = 'pink';
+
+    /**
+     * @return string
+     */
+    public function getColor(): string
+    {
+        return static::COLOR_PINK;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

Add support configure definitions through Reference

#### Input
```
$container = new \yii\di\Container();

$container->set(
    'service',
    [
        '__class' => \yiidiexample\objects\TestService::class,
        'model' => new \yii\di\Reference('model')
    ]
);

$container->set(
    'model',
    \yiidiexample\objects\TestModel::class
);

$service = $container->get('service');
```

#### Output
```
class yiidiexample\objects\TestService#5 (1) {
  public $model =>
  class yiidiexample\objects\TestModel#7 (1) {
    public $property =>
    int(10)
  }
}
```

### Classes

#### TestService
```
class TestService
{
    /**
     * @var \yiidiexample\objects\TestModel
     */
    public $model;
}
```

#### TestModel
```
class TestModel
{
    /**
     * @var int
     */
    public $property = 10;
}
```