### PR TITLE
Added support of service providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@ Yii Dependency Injection Change Log
 -----------------------
 
 - Initial release.
+- Added Service Providers support.

--- a/src/contracts/DelayedServiceProviderInterface.php
+++ b/src/contracts/DelayedServiceProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\contracts;
+
+/**
+ * Represents service provider that should be delayed to register till services are
+ * actually required.
+ *
+ * @author Dmitry Kolodko <prowwid@gmail.com>
+ * @since 1.0
+ */
+interface DelayedServiceProviderInterface extends ServiceProviderInterface
+{
+    /**
+     * Identifies whether service provider would register definition for
+     * given identifier or not.
+     *
+     * @param string $id class, interface or identifier in the Container.
+     * @return bool whether service provider would register definition or not.
+     */
+    public function hasDefinitionFor(string $id): bool;
+}

--- a/src/contracts/ServiceProviderInterface.php
+++ b/src/contracts/ServiceProviderInterface.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\contracts;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Represents a component responsible for class registration in the Container.
+ *
+ * The goal of service providers is to centralize and organize in one place
+ * registration of classes bound by any logic or classes with complex dependencies.
+ *
+ * You can simply organize registration of service and it's dependencies in a single
+ * provider class except of creating bootstrap file or configuration array for the Container.
+ *
+ * Example:
+ * ```php
+ * class CarProvider implements ServiceProvider
+ * {
+ *    public function register()
+ *    {
+ *        $this->registerDependencies();
+ *        $this->registerService();
+ *    }
+ *
+ *    protected function registerDependencies()
+ *    {
+ *        $container = $this->container;
+ *        $container->set(EngineInterface::class, SolarEngine::class);
+ *        $container->set(WheelInterface::class, [
+ *            '__class' => Wheel::class,
+ *            'color' => 'black',
+ *        ]);
+ *    }
+ *
+ *    protected function registerService()
+ *    {
+ *        $this->container->set(Car::class, [
+ *              '__class' => Car::class,
+ *              'color' => 'red',
+ *        ]);
+ *    }
+ * }
+ * ```
+ *
+ * @author Dmitry Kolodko <prowwid@gmail.com>
+ * @since 1.0
+ */
+interface ServiceProviderInterface
+{
+    /**
+     * Typical service provider constructor.
+     * @param ContainerInterface $container IoC container that must be used for services registration.
+     */
+    public function __construct(ContainerInterface $container);
+
+    /**
+     * Registers classes in the container.
+     *
+     * This method should only set classes definitions to the Container preventing
+     * any side-effects.
+     */
+    public function register(): void;
+}

--- a/src/contracts/ServiceProviderInterface.php
+++ b/src/contracts/ServiceProviderInterface.php
@@ -22,13 +22,20 @@ use Psr\Container\ContainerInterface;
  * ```php
  * class CarProvider implements ServiceProvider
  * {
- *    public function register()
+ *    protected $container;
+ *
+ *    public function __construct(ContainerInterface $container)
+ *    {
+ *        $this->container = $container;
+ *    }
+ *
+ *    public function register(): void
  *    {
  *        $this->registerDependencies();
  *        $this->registerService();
  *    }
  *
- *    protected function registerDependencies()
+ *    protected function registerDependencies(): void
  *    {
  *        $container = $this->container;
  *        $container->set(EngineInterface::class, SolarEngine::class);
@@ -38,7 +45,7 @@ use Psr\Container\ContainerInterface;
  *        ]);
  *    }
  *
- *    protected function registerService()
+ *    protected function registerService(): void
  *    {
  *        $this->container->set(Car::class, [
  *              '__class' => Car::class,

--- a/src/support/DelayedServiceProvider.php
+++ b/src/support/DelayedServiceProvider.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\support;
+
+use yii\di\contracts\DelayedServiceProviderInterface;
+
+/**
+ * Base class for service providers that should be delayed to register till services are
+ * actually required.
+ *
+ * Complex services with heavy dependencies might create redundant load during bootstrapping
+ * of an application so to reduce actions performed during the container bootstrap you can
+ *
+ * Delayed providers can be added to the Container like basic providers but won't register
+ * any definitions to the container till one of the classes listed in `provides` method would
+ * be requested from container. Example:
+ * ```php
+ * class CarProvider extends DelayedServiceProvider
+ * {
+ *     public function provides(): array
+ *     {
+ *         return [
+ *             Car::class,
+ *             CarFactory::class,
+ *         ];
+ *     }
+ *
+ *     public function register(): void
+ *     {
+ *         $container = $this->container;
+ *
+ *         $container->set(Car::class, Car::class);
+ *         $container->set(CarFactory::class, CarFactory::class);
+ *         $container->set(EngineInterface::class, EngineMarkOne::class);
+ *     }
+ * }
+ *
+ * $container->addProvider(CarProvider::class);
+ *
+ * $container->has(EngineInterface::class); // returns false provider wasn't registered
+ *
+ * $engine = $container->get(EngineInterface::class); // returns EngineMarkOne as provider was
+ * // registered once EngineInterface was requested from the container.
+ * ```
+ *
+ * @author Dmitry Kolodko <prowwid@gmail.com>
+ * @since 1.0
+ */
+abstract class DelayedServiceProvider extends ServiceProvider implements DelayedServiceProviderInterface
+{
+    /**
+     * Lists classes provided by service provider. Should be a list of class names
+     * or identifiers. Example:
+     *
+     * ```php
+     * return [
+     *      Car::class,
+     *      EngineInterface::class,
+     *      'car-factory',
+     * ];
+     * ```
+     *
+     * @return array list of provided classes.
+     */
+    abstract public function provides(): array;
+
+    /**
+     * Identifies whether service provider would register definition for
+     * given identifier or not.
+     *
+     * @param string $id class, interface or identifier in the Container.
+     * @return bool whether service provider would register definition or not.
+     */
+    public function hasDefinitionFor(string $id): bool
+    {
+        return in_array($id, $this->provides());
+    }
+}

--- a/src/support/DelayedServiceProvider.php
+++ b/src/support/DelayedServiceProvider.php
@@ -20,6 +20,8 @@ use yii\di\contracts\DelayedServiceProviderInterface;
  * any definitions to the container till one of the classes listed in `provides` method would
  * be requested from container. Example:
  * ```php
+ * use yii\di\support\DelayedServiceProvider;
+ *
  * class CarProvider extends DelayedServiceProvider
  * {
  *     public function provides(): array

--- a/src/support/DelayedServiceProvider.php
+++ b/src/support/DelayedServiceProvider.php
@@ -80,6 +80,6 @@ abstract class DelayedServiceProvider extends ServiceProvider implements Delayed
      */
     public function hasDefinitionFor(string $id): bool
     {
-        return in_array($id, $this->provides());
+        return in_array($id, $this->provides(), true);
     }
 }

--- a/src/support/ServiceProvider.php
+++ b/src/support/ServiceProvider.php
@@ -23,15 +23,17 @@ use yii\di\contracts\ServiceProviderInterface;
  *
  * Example:
  * ```php
- * class CarProvider implements ServiceProvider
+ * use yii\di\support\ServiceProvider;
+ *
+ * class CarProvider extends ServiceProvider
  * {
- *    public function register()
+ *    public function register(): void
  *    {
  *        $this->registerDependencies();
  *        $this->registerService();
  *    }
  *
- *    protected function registerDependencies()
+ *    protected function registerDependencies(): void
  *    {
  *        $container = $this->container;
  *        $container->set(EngineInterface::class, SolarEngine::class);
@@ -41,7 +43,7 @@ use yii\di\contracts\ServiceProviderInterface;
  *        ]);
  *    }
  *
- *    protected function registerService()
+ *    protected function registerService(): void
  *    {
  *        $this->container->set(Car::class, [
  *              '__class' => Car::class,

--- a/src/support/ServiceProvider.php
+++ b/src/support/ServiceProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\support;
+
+use Psr\Container\ContainerInterface;
+use yii\di\contracts\ServiceProviderInterface;
+
+/**
+ * Base class for service providers - components responsible for class
+ * registration in the Container.
+ *
+ * The goal of service providers is to centralize and organize in one place
+ * registration of classes bound by any logic or classes with complex dependencies.
+ *
+ * You can simply organize registration of service and it's dependencies in a single
+ * provider class except of creating bootstrap file or configuration array for the Container.
+ *
+ * Example:
+ * ```php
+ * class CarProvider implements ServiceProvider
+ * {
+ *    public function register()
+ *    {
+ *        $this->registerDependencies();
+ *        $this->registerService();
+ *    }
+ *
+ *    protected function registerDependencies()
+ *    {
+ *        $container = $this->container;
+ *        $container->set(EngineInterface::class, SolarEngine::class);
+ *        $container->set(WheelInterface::class, [
+ *            '__class' => Wheel::class,
+ *            'color' => 'black',
+ *        ]);
+ *    }
+ *
+ *    protected function registerService()
+ *    {
+ *        $this->container->set(Car::class, [
+ *              '__class' => Car::class,
+ *              'color' => 'red',
+ *        ]);
+ *    }
+ * }
+ * ```
+ *
+ * @author Dmitry Kolodko <prowwid@gmail.com>
+ * @since 1.0
+ */
+abstract class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @var ContainerInterface|\yii\di\Container container, service provider assigned to.
+     */
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+}

--- a/tests/DelayedServiceProviderTest.php
+++ b/tests/DelayedServiceProviderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace yii\di\tests;
+
+use PHPUnit\Framework\TestCase;
+use yii\di\Container;
+use yii\di\tests\code\Car;
+use yii\di\tests\code\CarDelayedProvider;
+use yii\di\tests\code\EngineInterface;
+use yii\di\tests\code\EngineMarkOne;
+
+/**
+ * Test for {@link \yii\di\support\DelayedServiceProvider}
+ *
+ * @author Dmitry Kolodko <prowwid@gmail.com>
+ */
+class DelayedServiceProviderTest extends TestCase
+{
+    public function testServiceProviderDelay()
+    {
+        $container = new Container();
+
+        $this->assertFalse($container->has(Car::class), 'Container should not have Car before service provider added.');
+        $this->assertFalse($container->has(EngineInterface::class), 'Container should not have EngineInterface before service provider added.');
+
+        $container->addProvider(CarDelayedProvider::class);
+
+        $this->assertFalse($container->has(Car::class), 'Container should not have Car after adding delayed provider.');
+        $this->assertFalse($container->has(EngineInterface::class), 'Container should not have EngineInterface after adding delayed provider.');
+
+        $car = $container->get(Car::class);
+        $engine = $container->get(EngineInterface::class);
+
+        // ensure container return instances of classes register from provider
+        $this->assertInstanceOf(Car::class, $car, 'Service provider should have set correct class for a Car.');
+        $this->assertInstanceOf(EngineMarkOne::class, $engine, 'Service provider should have set EngineInterface as an EngineMarkOne.');
+
+        // ensure get invoked DelayedServiceProviderInterface::register
+        $this->assertTrue($container->has(Car::class), 'CarDelayedProvider should have registered Car once Car was requested from container.');
+        $this->assertTrue($container->has(EngineInterface::class), 'CarDelayedProvider should have registered EngineInterface once Car was requested from container.');
+    }
+}

--- a/tests/ServiceProviderTest.php
+++ b/tests/ServiceProviderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace yii\di\tests;
+
+use PHPUnit\Framework\TestCase;
+use yii\di\Container;
+use yii\di\InvalidConfigException;
+use yii\di\tests\code\Car;
+use yii\di\tests\code\CarFactory;
+use yii\di\tests\code\CarProvider;
+
+/**
+ * Test for {@link Container} and {@link \yii\di\support\ServiceProvider}
+ *
+ * @author Dmitry Kolodko <prowwid@gmail.com>
+ */
+class ServiceProviderTest extends TestCase
+{
+    public function testAddProviderByClassName()
+    {
+        $this->ensureProviderRegisterDefinitions(CarProvider::class);
+    }
+
+    public function testAddProviderByDefinition()
+    {
+        $this->ensureProviderRegisterDefinitions([
+            '__class' => CarProvider::class,
+        ]);
+    }
+
+    protected function ensureProviderRegisterDefinitions($provider)
+    {
+        $container = new Container();
+
+        $this->assertFalse($container->has(Car::class), 'Container should not have Car registered before service provider added.');
+        $this->assertFalse($container->has(CarFactory::class), 'Container should not have CarFactory registered before service provider added.');
+
+        $container->addProvider($provider);
+
+        // ensure addProvider invoked ServiceProviderInterface::register
+        $this->assertTrue($container->has(Car::class), 'CarProvider should have registered Car once it was added to container.');
+        $this->assertTrue($container->has(CarFactory::class), 'CarProvider should have registered CarFactory once it was added to container.');
+
+    }
+
+    public function testAddProviderRejectObject()
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Service provider definition should be a class name or array contains "__class" with a class name of provider.');
+
+        $container = new Container();
+        $container->addProvider(new CarProvider($container));
+    }
+
+    public function testAddProviderRejectDefinitionWithoutClass()
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Service provider definition should be a class name or array contains "__class" with a class name of provider.');
+
+        $container = new Container();
+        $container->addProvider([
+            'property' => 234
+        ]);
+    }
+}

--- a/tests/code/CarDelayedProvider.php
+++ b/tests/code/CarDelayedProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace yii\di\tests\code;
+
+use yii\di\support\DelayedServiceProvider;
+
+
+class CarDelayedProvider extends DelayedServiceProvider
+{
+    public function provides(): array
+    {
+        return [
+            Car::class,
+            CarFactory::class,
+        ];
+    }
+
+    public function register(): void
+    {
+        $this->container->set(Car::class, Car::class);
+        $this->container->set(CarFactory::class, CarFactory::class);
+        $this->container->set(EngineInterface::class, EngineMarkOne::class);
+    }
+}

--- a/tests/code/CarProvider.php
+++ b/tests/code/CarProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+
+namespace yii\di\tests\code;
+
+use yii\di\support\ServiceProvider;
+
+
+class CarProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->container->set(Car::class, Car::class);
+        $this->container->set(CarFactory::class, CarFactory::class);
+    }
+}


### PR DESCRIPTION
Implementation of [\[Feature Proposal\] Add Service Providers](https://github.com/yiisoft/di/issues/9)

Changes:
- added `contracts` namespace to keep interfaces organized except of mixing them with implementations
- added namespace `support` to organize base service providers and for further possible usage for organization of support classes
- added ability to set `providers` list in container definitions array to easily add providers on container bootstrap

| Q             | A
| ------------- | ---
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
