### PR TITLE
#15: improved deferred service provider naming for better readability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,20 +214,20 @@ dependencies. Once a service providers is added through `addProvider` method or 
 **Note**, service provider might decrease performance of your application if you would perform heavy operations
 inside the `register` method.
 
-## Using delayed service providers
+## Using deferred service providers
 
 As stated before, service provider might decrease performance of your application registering heavy services. So
-to prevent performance decrease you can use so-called delayed service providers. 
+to prevent performance decrease you can use so-called deferred service providers. 
 
-Delayed service providers extend the `yii\di\support\DelayedServiceProvider` and in addition to `register` method
+deferred service providers extend the `yii\di\support\DeferredServiceProvider` and in addition to `register` method
 contain a `provides` method that returns array with names and identifiers of services service providers bind to 
-the container. Delayed service providers being added to the container the same way as regular service providers but 
-`register` method of delayed service provider got called only once one of the services listed in `provides` method 
+the container. Deferred service providers being added to the container the same way as regular service providers but 
+`register` method of deferred service provider got called only once one of the services listed in `provides` method 
 is requested from the container. Example:
 ```php
-use yii\di\support\DelayedServiceProvider;
+use yii\di\support\DeferredServiceProvider;
 
-class CarFactoryProvider extends DelayedServiceProvider
+class CarFactoryProvider extends DeferredServiceProvider
 {
     public function provides(): array
     {
@@ -287,7 +287,7 @@ executed till `EngineInterface` was requested from the container. When we reques
 `provides` list of the `CarFactoryProvider` and, as `EngineInterface` is listed in `provides`, container called `register`
 method of the `CarFactoryProvider`.
 
-**Note**, you can use delayed service providers not just to delay bootstrap of heavy services but also to register your 
+**Note**, you can use deferred service providers not just to defer bootstrap of heavy services but also to register your 
 services to the container only when they are actually needed. 
 
 ## Further reading

--- a/src/contracts/DeferredServiceProviderInterface.php
+++ b/src/contracts/DeferredServiceProviderInterface.php
@@ -8,13 +8,13 @@
 namespace yii\di\contracts;
 
 /**
- * Represents service provider that should be delayed to register till services are
+ * Represents service provider that should be deferred to register till services are
  * actually required.
  *
  * @author Dmitry Kolodko <prowwid@gmail.com>
  * @since 1.0
  */
-interface DelayedServiceProviderInterface extends ServiceProviderInterface
+interface DeferredServiceProviderInterface extends ServiceProviderInterface
 {
     /**
      * Identifies whether service provider would register definition for

--- a/src/support/DeferredServiceProvider.php
+++ b/src/support/DeferredServiceProvider.php
@@ -7,22 +7,22 @@
 
 namespace yii\di\support;
 
-use yii\di\contracts\DelayedServiceProviderInterface;
+use yii\di\contracts\DeferredServiceProviderInterface;
 
 /**
- * Base class for service providers that should be delayed to register till services are
+ * Base class for service providers that should be deferred to register till services are
  * actually required.
  *
  * Complex services with heavy dependencies might create redundant load during bootstrapping
  * of an application so to reduce actions performed during the container bootstrap you can
  *
- * Delayed providers can be added to the Container like basic providers but won't register
+ * Deferred providers can be added to the Container like basic providers but won't register
  * any definitions to the container till one of the classes listed in `provides` method would
  * be requested from container. Example:
  * ```php
- * use yii\di\support\DelayedServiceProvider;
+ * use yii\di\support\DeferredServiceProvider;
  *
- * class CarProvider extends DelayedServiceProvider
+ * class CarProvider extends DeferredServiceProvider
  * {
  *     public function provides(): array
  *     {
@@ -53,7 +53,7 @@ use yii\di\contracts\DelayedServiceProviderInterface;
  * @author Dmitry Kolodko <prowwid@gmail.com>
  * @since 1.0
  */
-abstract class DelayedServiceProvider extends ServiceProvider implements DelayedServiceProviderInterface
+abstract class DeferredServiceProvider extends ServiceProvider implements DeferredServiceProviderInterface
 {
     /**
      * Lists classes provided by service provider. Should be a list of class names

--- a/tests/DeferredServiceProviderTest.php
+++ b/tests/DeferredServiceProviderTest.php
@@ -5,18 +5,18 @@ namespace yii\di\tests;
 use PHPUnit\Framework\TestCase;
 use yii\di\Container;
 use yii\di\tests\code\Car;
-use yii\di\tests\code\CarDelayedProvider;
+use yii\di\tests\code\CarDeferredProvider;
 use yii\di\tests\code\EngineInterface;
 use yii\di\tests\code\EngineMarkOne;
 
 /**
- * Test for {@link \yii\di\support\DelayedServiceProvider}
+ * Test for {@link \yii\di\support\DeferredServiceProvider}
  *
  * @author Dmitry Kolodko <prowwid@gmail.com>
  */
-class DelayedServiceProviderTest extends TestCase
+class DeferredServiceProviderTest extends TestCase
 {
-    public function testServiceProviderDelay()
+    public function testServiceProviderDeferring()
     {
         $container = new Container();
 
@@ -26,12 +26,12 @@ class DelayedServiceProviderTest extends TestCase
             'Container should not have EngineInterface before service provider added.'
         );
 
-        $container->addProvider(CarDelayedProvider::class);
+        $container->addProvider(CarDeferredProvider::class);
 
-        $this->assertFalse($container->has(Car::class), 'Container should not have Car after adding delayed provider.');
+        $this->assertFalse($container->has(Car::class), 'Container should not have Car after adding deferred provider.');
         $this->assertFalse(
             $container->has(EngineInterface::class),
-            'Container should not have EngineInterface after adding delayed provider.'
+            'Container should not have EngineInterface after adding deferred provider.'
         );
 
         $car = $container->get(Car::class);
@@ -45,14 +45,14 @@ class DelayedServiceProviderTest extends TestCase
             'Service provider should have set EngineInterface as an EngineMarkOne.'
         );
 
-        // ensure get invoked DelayedServiceProviderInterface::register
+        // ensure get invoked DeferredServiceProviderInterface::register
         $this->assertTrue(
             $container->has(Car::class),
-            'CarDelayedProvider should have registered Car once Car was requested from container.'
+            'CarDeferredProvider should have registered Car once Car was requested from container.'
         );
         $this->assertTrue(
             $container->has(EngineInterface::class),
-            'CarDelayedProvider should have registered EngineInterface once Car was requested from container.'
+            'CarDeferredProvider should have registered EngineInterface once Car was requested from container.'
         );
     }
 }

--- a/tests/code/CarDeferredProvider.php
+++ b/tests/code/CarDeferredProvider.php
@@ -2,9 +2,9 @@
 
 namespace yii\di\tests\code;
 
-use yii\di\support\DelayedServiceProvider;
+use yii\di\support\DeferredServiceProvider;
 
-class CarDelayedProvider extends DelayedServiceProvider
+class CarDeferredProvider extends DeferredServiceProvider
 {
     public function provides(): array
     {


### PR DESCRIPTION
Renamed `DelayedServiceProvider` to `DeferredServiceProvider`


| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | only if someone used dev branch
| Tests pass?   | yes
| Fixed issues  |  # 15
