### PR TITLE
Dropped aliases in favour of `Reference`, closes #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ on autowiring made via Injector (see below).
 
 ## Using aliases
 
-Container supports aliases with use of `Reference`. It could be useful to have an ability
+Container supports aliases via `Reference` class. It could be useful to have an ability
 to retrieve objects both by their interface and named explicitly:
 
 ```php

--- a/README.md
+++ b/README.md
@@ -97,14 +97,14 @@ on autowiring made via Injector (see below).
 
 ## Using aliases
 
-Container supports aliases. It could be useful to have an ability to retrieve objects both by their
-interface and named explicitly:
+Container supports aliases with use of `Reference`. It could be useful to have an ability
+to retrieve objects both by their interface and named explicitly:
 
 ```php
 $container = new Container([
     EngineInterface::class => EngineMarkOne::class,
+    'engine_one' => EngineInterface::class,
 ]);
-$container->addAlias('engine_one', EngineInterface::class);
 ```
 
 ## Nesting containers

--- a/src/Container.php
+++ b/src/Container.php
@@ -236,20 +236,24 @@ class Container implements ContainerInterface
     }
 
     /**
-     * Follows references recursively to find deepest ID.
+     * Follows references recursively to find the deepest ID.
      *
      * @param string $id
+     * @return string
      */
-    public function dereference($id)
+    private function dereference($id)
     {
-        if (isset($this->definitions[$id]) && $this->definitions[$id] instanceof Reference) {
-            if (isset($this->dereferencing[$id])) {
-                throw new CircularReferenceException("Circular reference to \"$id\" detected.");
-            }
-            $this->dereferencing[$id] = 1;
-            $id = $this->dereference($this->definitions[$id]->getId());
-            unset($this->dereferencing[$id]);
+        if (!isset($this->definitions[$id]) || !$this->definitions[$id] instanceof Reference) {
+            return $id;
         }
+
+        if (isset($this->dereferencing[$id])) {
+            throw new CircularReferenceException("Circular reference to \"$id\" detected.");
+        }
+
+        $this->dereferencing[$id] = 1;
+        $id = $this->dereference($this->definitions[$id]->getId());
+        unset($this->dereferencing[$id]);
 
         return $id;
     }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -106,9 +106,22 @@ class ContainerTest extends TestCase
     public function testAlias()
     {
         $container = new Container();
+        $container->set('engine-mark-one', Reference::to('engine'));
         $container->set('engine', EngineMarkOne::class);
-        $container->setAlias(EngineInterface::class, 'engine');
+        $container->set(EngineInterface::class, Reference::to('engine'));
+        $this->assertInstanceOf(EngineMarkOne::class, $container->get('engine-mark-one'));
         $this->assertInstanceOf(EngineMarkOne::class, $container->get(EngineInterface::class));
+    }
+
+    public function testCircularAlias()
+    {
+        $container = new Container();
+        $container->set('engine-1', Reference::to('engine-2'));
+        $container->set('engine-2', Reference::to('engine-3'));
+        $container->set('engine-3', Reference::to('engine-1'));
+
+        $this->expectException(CircularReferenceException::class);
+        $container->get('engine-1');
     }
 
     public function testUndefinedDependencies()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| New feature?  | yes
| Breaks BC?    | yes - removed `Container::setAlias()`
| Tests pass?   | yes
| Fixed issues  | #27 

I've implemented recursive dereferencing with detection of circular references.

Another options like optimizing with dereferencing in `set` or complete prohibition of reference to reference are not easily achievable because of the following scenario:

```php
$container->set('engine-1', EngineMarkOne::class);
$container->set('engine-2', Reference::to('engine-1');
$container->set('engine-1', Reference::to(EngineMarkTwo::class));
```
