### PR TITLE
Added `Factory`, see #25

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Container implements a [dependency injection](http://en.wikipedia.org/wiki/Dependency_injection) container.
+ *
+ * @author Alexander Makarov <sam@rmcreative.ru>
+ * @since 1.0
+ */
+class Container extends AbstractContainer implements ContainerInterface
+{
+    /**
+     * @var object[]
+     */
+    private $instances;
+
+    public function set(string $id, $definition): void
+    {
+        $this->instances[$id] = null;
+
+        parent::set($id, $definition);
+    }
+
+    /**
+     * Returns an instance by either interface name or alias.
+     *
+     * Same instance of the class will be returned each time this method is called.
+     *
+     * @param string $id the interface name or an alias name (e.g. `foo`) that was previously registered via [[set()]].
+     * @return object an instance of the requested interface.
+     */
+    public function get($id)
+    {
+        $id = $this->dereference($id);
+
+        if (isset($this->instances[$id])) {
+            return $this->instances[$id];
+        }
+
+        $object = $this->build($id);
+        $this->instances[$id] = $object;
+
+        return $object;
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di;
+
+/**
+ * Factory is similar to the Container but creates new object every time.
+ *
+ * @author Andrii Vasyliev <sol@hiqdev.com>
+ * @since 1.0
+ */
+class Factory extends AbstractContainer
+{
+    public function create($id, array $config = [])
+    {
+        return $this->build($id, $config);
+    }
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -206,4 +206,13 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(Car::class, $object);
         $this->assertInstanceOf(ColorPink::class, $object->color);
     }
+
+    public function testSameInstance()
+    {
+        $container = new Container();
+        $container->set('engine', EngineMarkOne::class);
+        $one = $container->get('engine');
+        $two = $container->get('engine');
+        $this->assertSame($one, $two);
+    }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace yii\di\tests;
+
+use PHPUnit\Framework\TestCase;
+use yii\di\Factory;
+use yii\di\tests\code\EngineMarkOne;
+
+/**
+ * FactoryTest contains tests for \yii\di\Factory
+ */
+class FactoryTest extends TestCase
+{
+    public function testCreatesNew()
+    {
+        $factory = new Factory();
+        $factory->set('engine', EngineMarkOne::class);
+        $one = $factory->create('engine');
+        $two = $factory->create('engine');
+        $this->assertFalse($one === $two);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Related issues | #25, #26  

Actually changes are minimal but are shown huge because of renamed file. Done in three commits to allow explore diffs.

Highlights:

- **AbstractContainer**
  - `protected build($id, $config)`
  - `protected buildFromDefinition($definition)`
  - **Factory**
    - `public create($id, $config)` - new instance every time
  - **Container** implements PSR11
    - `private $instances`
    - `public get($id)` - same instance every time

