### PR TITLE
Added `Initable` interface and `configure()`

### DIFF
--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -339,6 +339,10 @@ abstract class AbstractContainer
             }
         }
 
+        if ($object instanceof Initable) {
+            $object->init();
+        }
+
         return $object;
     }
 

--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -324,6 +324,7 @@ abstract class AbstractContainer
 
     /**
      * Configures an object with the given configuration.
+     * @deprecated Not recommended for explicit use. Added only to support Yii 2.0 behavior.
      * @param object $object the object to be configured
      * @param iterable $config property values and methods to call
      * @return object the object itself

--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -15,6 +15,7 @@ use yii\di\exceptions\CircularReferenceException;
 use yii\di\exceptions\InvalidConfigException;
 use yii\di\exceptions\NotFoundException;
 use yii\di\exceptions\NotInstantiableException;
+use yii\di\Initable;
 
 /**
  * Container implements a [dependency injection](http://en.wikipedia.org/wiki/Dependency_injection) container.

--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -318,6 +318,17 @@ abstract class AbstractContainer
 
         $config = $this->resolveDependencies($config);
 
+        return static::configure($object, $config);
+    }
+
+    /**
+     * Configures an object with the given configuration.
+     * @param object $object the object to be configured
+     * @param iterable $config property values and methods to call
+     * @return object the object itself
+     */
+    public static function configure($object, iterable $config)
+    {
         foreach ($config as $action => $arguments) {
             if (substr($action, -2) === '()') {
                 // method call

--- a/src/Initable.php
+++ b/src/Initable.php
@@ -8,7 +8,8 @@
 namespace yii\di;
 
 /**
- * Initable interface.
+ * Initable interface to mark classes needing `init()` after construction.
+ * @deprecated Not recommended for use. Added only to support Yii 2.0 behavior.
  *
  * @author Andrii Vasyliev <sol@hiqdev.com>
  * @since 1.0
@@ -18,6 +19,7 @@ interface Initable
     /**
      * Initializes the object.
      * This method is invoked after object created and configured.
+     * @deprecated use constructor and getters/setters instead
      */
     public function init();
 }

--- a/src/Initable.php
+++ b/src/Initable.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di;
+
+/**
+ * Initable interface.
+ *
+ * @author Andrii Vasyliev <sol@hiqdev.com>
+ * @since 1.0
+ */
+interface Initable
+{
+    /**
+     * Initializes the object.
+     * This method is invoked after object created and configured.
+     */
+    public function init();
+}

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -15,6 +15,7 @@ use yii\di\tests\code\ConstructorTestClass;
 use yii\di\tests\code\EngineInterface;
 use yii\di\tests\code\EngineMarkOne;
 use yii\di\tests\code\EngineMarkTwo;
+use yii\di\tests\code\GearBox;
 use yii\di\tests\code\CarFactory;
 use yii\di\tests\code\InvokeableCarFactory;
 use yii\di\tests\code\MethodTestClass;
@@ -224,5 +225,15 @@ class ContainerTest extends TestCase
         $this->assertFalse($container->hasInstance('engine'));
         $one = $container->get('engine');
         $this->assertTrue($container->hasInstance('engine'));
+    }
+
+    public function testInitable()
+    {
+        $container = new Container();
+        $container->set('gearbox', GearBox::class);
+        $manual = new GearBox();
+        $this->assertFalse($manual->getInited());
+        $automatic = $container->get('gearbox');
+        $this->assertTrue($automatic->getInited());
     }
 }

--- a/tests/code/GearBox.php
+++ b/tests/code/GearBox.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace yii\di\tests\code;
+
+use yii\di\Initable;
+
+/**
+ * A gear box.
+ */
+class GearBox implements Initable
+{
+    private $maxGear;
+
+    /**
+     * @var bool
+     */
+    private $inited = false;
+
+    public function __construct(int $maxGear = null)
+    {
+        $this->maxGear = $maxGear ?: 5;
+    }
+
+    public function init()
+    {
+        $this->inited = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getInited(): bool
+    {
+        return $this->inited;
+    }
+}


### PR DESCRIPTION
To reconstruct former Yii DI behaviour in a more structured manner.

`configure()` should not be used explicitly and have intentionally very long full name `yii\di\AbstractContainer::configure()` to distract from using it.

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | YES
| Breaks BC?    | no
| Tests pass?   | yes
