### PR TITLE
Correct judgment condition

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -22,7 +22,7 @@ class Factory extends AbstractContainer implements FactoryInterface
      */
     public function get($id)
     {
-        if (!isset($this->definitions[$id]) && $this->parent !== null) {
+        if ($this->getDefinition($id) == null && $this->parent !== null) {
             return $this->parent->get($id);
         }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -27,4 +27,21 @@ class FactoryTest extends TestCase
         $two = $factory->create(EngineMarkOne::class);
         $this->assertFalse($one === $two);
     }
+
+    /**
+     * @depends testCreatesNewByAlias
+     * @throws \yii\di\exceptions\CircularReferenceException
+     * @throws \yii\di\exceptions\InvalidConfigException
+     * @throws \yii\di\exceptions\NotFoundException
+     * @throws \yii\di\exceptions\NotInstantiableException
+     */
+    public function testGet()
+    {
+        $factory = new Factory();
+        $factory->set('engine', EngineMarkOne::class);
+        $one = $factory->create('engine');
+        $one_got = $factory->get('engine');
+        $this->assertNotNull($one_got);
+        $this->assertInstanceOf(EngineMarkOne::class, $one_got);
+    }
 }


### PR DESCRIPTION
$definitions is defined in the parent class and is private.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Correct the conditions for determining whether a definition exists.


