### PR TITLE
Check $config content when AbstractContainer::configure called

### DIFF
--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -384,13 +384,15 @@ abstract class AbstractContainer implements ContainerInterface
      */
     public static function configure($object, iterable $config)
     {
-        foreach ($config as $action => $arguments) {
-            if (substr($action, -2) === '()') {
-                // method call
-                \call_user_func_array([$object, substr($action, 0, -2)], $arguments);
-            } else {
-                // property
-                $object->$action = $arguments;
+        if (!empty($config)) {
+            foreach ($config as $action => $arguments) {
+                if (substr($action, -2) === '()') {
+                    // method call
+                    \call_user_func_array([$object, substr($action, 0, -2)], $arguments);
+                } else {
+                    // property
+                    $object->$action = $arguments;
+                }
             }
         }
 


### PR DESCRIPTION
Related to issue https://github.com/yiisoft/db/issues/42

I think that it should be better check $config content inside ::configure(), instead delegate this to developer calling.