### PR TITLE
ResolveInterface for referencing objects implemented

### DIFF
--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -450,8 +450,8 @@ abstract class AbstractContainer implements ContainerInterface
     {
         foreach ($dependencies as $index => $dependency) {
             if ($dependency instanceof Reference) {
-                if ($dependency->getId() !== null) {
-                    $dependencies[$index] = $this->get($dependency->getId());
+                if ($dependency->isDefined()) {
+                    $dependencies[$index] =  $dependency->get($this);
                 } elseif ($reflection !== null) {
                     $name = $reflection->getConstructor()->getParameters()[$index]->getName();
                     $class = $reflection->getName();

--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -449,7 +449,7 @@ abstract class AbstractContainer implements ContainerInterface
     protected function resolveDependencies($dependencies, $reflection = null): array
     {
         foreach ($dependencies as $index => $dependency) {
-            if ($dependency instanceof Reference) {
+            if ($dependency instanceof ResolveInterface) {
                 if ($dependency->isDefined()) {
                     $dependencies[$index] =  $dependency->get($this);
                 } elseif ($reflection !== null) {

--- a/src/CallableReference.php
+++ b/src/CallableReference.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace yii\di;
+
+/**
+ * Reference to a callable function
+ * 
+ * The function is called when the reference is resolved by the container.
+ * 
+ * The container is passed to the function as first parameter. 
+ *
+ * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
+ */
+class CallableReference implements ResolveInterface
+{
+
+    /**
+     * @var callable 
+     */
+    public $func;
+    
+    /**
+     * Constructor.
+     * @param callable $func
+     */
+    public function __construct(callable $func)
+    {
+        $this->func = $func;
+    }
+
+    /**
+     * Creates an instance of a reference to the given callable
+     * @param callable $func
+     */
+    public static function to(callable $func)
+    {
+        return new static ($func);
+    }
+    
+    /**
+     * Calls the referenced function
+     * @param \Psr\Container\ContainerInterface|null $container 
+     */
+    public function get(?\Psr\Container\ContainerInterface $container = null)
+    {
+        return call_user_func($this->func, $container);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isDefined()
+    {
+        return is_callable($this->func);
+    }
+
+}

--- a/src/CallableReference.php
+++ b/src/CallableReference.php
@@ -1,9 +1,8 @@
 <?php
-
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
  */
 
 namespace yii\di;

--- a/src/CallableReference.php
+++ b/src/CallableReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -9,10 +10,10 @@ namespace yii\di;
 
 /**
  * Reference to a callable function
- * 
+ *
  * The function is called when the reference is resolved by the container.
- * 
- * The container is passed to the function as first parameter. 
+ *
+ * The container is passed to the function as first parameter.
  *
  * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
  */
@@ -20,10 +21,10 @@ class CallableReference implements ResolveInterface
 {
 
     /**
-     * @var callable 
+     * @var callable
      */
     public $func;
-    
+
     /**
      * Constructor.
      * @param callable $func
@@ -39,12 +40,12 @@ class CallableReference implements ResolveInterface
      */
     public static function to(callable $func)
     {
-        return new static ($func);
+        return new static($func);
     }
-    
+
     /**
      * Calls the referenced function
-     * @param \Psr\Container\ContainerInterface|null $container 
+     * @param \Psr\Container\ContainerInterface|null $container
      */
     public function get(?\Psr\Container\ContainerInterface $container = null)
     {

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -96,9 +96,9 @@ class Factory extends AbstractContainer implements FactoryInterface
 
         if ($reference instanceof Reference) {
             try {
-                $component = $this->get($reference->getId());
+                $component = $reference->get($this);
             } catch (\ReflectionException $e) {
-                throw new InvalidConfigException("Failed instantiate component or class '{$reference->id}'.", 0, $e);
+                throw new InvalidConfigException("Failed instantiate component or class '{(string)$reference}'.", 0, $e);
             }
             if ($type === null || $component instanceof $type) {
                 return $component;
@@ -106,7 +106,7 @@ class Factory extends AbstractContainer implements FactoryInterface
 
             throw new InvalidConfigException(sprintf(
                 "'%s' refers to a %s component. %s is expected.",
-                $reference->id,
+                (string)$reference,
                 \get_class($component),
                 $type
             ));

--- a/src/Reference.php
+++ b/src/Reference.php
@@ -8,6 +8,8 @@
 namespace yii\di;
 
 use yii\di\exceptions\InvalidConfigException;
+use Psr\Container\ContainerInterface;
+use yii\di\exceptions\InvalidArgumentException;
 
 /**
  * Reference points to another container definition by its ID
@@ -15,7 +17,7 @@ use yii\di\exceptions\InvalidConfigException;
  * @author Alexander Makarov <sam@rmcreative.ru>
  * @since 1.0
  */
-class Reference
+class Reference implements ResolveInterface
 {
     /**
      * @var string the component ID, class name, interface name or alias name
@@ -69,5 +71,38 @@ class Reference
     public function getId(): ?string
     {
         return $this->id;
+    }
+    
+    /**
+     * Reference as string
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getId();
+    }
+    
+    /**
+     * Returns the instance of the referenced object
+     * @param ContainerInterface $container Container to use to resolve the reference
+     * @throws InvalidArgumentException if container is missing
+     */
+    public function get(?ContainerInterface $container = null)
+    {
+        if (!isset($container)) {
+            throw new InvalidArgumentException(
+                    'Failed to get instance of "'.(string)$this.'". Parameter "container" is missing');
+        }
+        
+        return $container->get($this->getId());
+    }
+    
+    /**
+     * Returns wether this is a valid reference
+     * @return bool `true` if id is set
+     */
+    public function isDefined()
+    {
+        return ($this->id !== null);
     }
 }

--- a/src/ReferencingArray.php
+++ b/src/ReferencingArray.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di;
+
+use yii\di\exceptions\InvalidConfigException;
+use Psr\Container\ContainerInterface;
+use yii\di\exceptions\InvalidArgumentException;
+
+/**
+ * Array containing References
+ * 
+ * All items containing a reference ([[Reference]], [[ReferencingArray]] or any other 
+ * object implementing [[ResolveInterface]] are resolved by the container [[get()]].
+ * Items of other type are left unchanged. 
+ *
+ * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
+ */
+class ReferencingArray implements ResolveInterface
+{
+    
+    /**
+     * @var array Items of the array
+     */
+    public $items = [];
+    
+    /**
+     * Constructor
+     * @param array $items Items of the array
+     */
+    public function __construct(?array $items = null)
+    {
+        $this->items = $items;
+    }
+    
+    /**
+     * Creates a instance containing the given items
+     * @param array $items 
+     */
+    public static function items(?array $items = null)
+    {
+        return new static ($items);
+    }
+    
+    public function __toString()
+    {
+        'Referencing Array';
+    }
+    
+    /**
+     * Returns the instance of the referenced object
+     * @param ContainerInterface $container Container to use to resolve the reference
+     * @throws InvalidArgumentException if container is missing
+     */
+    public function get(?ContainerInterface $container = null)
+    {
+        if (!isset($container)) {
+            throw new InvalidArgumentException(
+                    'Failed to get instance of "'.(string)$this.'". Parameter "container" is missing');
+        }
+        
+        $result = $this->items;
+        if (is_array($result)) {
+            foreach ($result as $k => $v) {
+                if ($v instanceof ResolveInterface) {
+                    $result[$k] = $v->get($container);
+                }
+            }
+        }
+        return $result;
+    }
+    
+    /**
+     * Returns wether this is a valid reference
+     * @return bool `true` if id is set
+     */
+    public function isDefined()
+    {
+        return ($this->items !== null);
+    }
+    
+}

--- a/src/ReferencingArray.php
+++ b/src/ReferencingArray.php
@@ -13,21 +13,21 @@ use yii\di\exceptions\InvalidArgumentException;
 
 /**
  * Array containing References
- * 
- * All items containing a reference ([[Reference]], [[ReferencingArray]] or any other 
+ *
+ * All items containing a reference ([[Reference]], [[ReferencingArray]] or any other
  * object implementing [[ResolveInterface]] are resolved by the container [[get()]].
- * Items of other type are left unchanged. 
+ * Items of other type are left unchanged.
  *
  * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
  */
 class ReferencingArray implements ResolveInterface
 {
-    
+
     /**
      * @var array Items of the array
      */
     public $items = [];
-    
+
     /**
      * Constructor
      * @param array $items Items of the array
@@ -36,21 +36,21 @@ class ReferencingArray implements ResolveInterface
     {
         $this->items = $items;
     }
-    
+
     /**
      * Creates a instance containing the given items
-     * @param array $items 
+     * @param array $items
      */
     public static function items(?array $items = null)
     {
-        return new static ($items);
+        return new static($items);
     }
-    
+
     public function __toString()
     {
         'Referencing Array';
     }
-    
+
     /**
      * Returns the instance of the referenced object
      * @param ContainerInterface $container Container to use to resolve the reference
@@ -60,9 +60,9 @@ class ReferencingArray implements ResolveInterface
     {
         if (!isset($container)) {
             throw new InvalidArgumentException(
-                    'Failed to get instance of "'.(string)$this.'". Parameter "container" is missing');
+                    'Failed to get instance of "' . (string) $this . '". Parameter "container" is missing');
         }
-        
+
         $result = $this->items;
         if (is_array($result)) {
             foreach ($result as $k => $v) {
@@ -73,7 +73,7 @@ class ReferencingArray implements ResolveInterface
         }
         return $result;
     }
-    
+
     /**
      * Returns wether this is a valid reference
      * @return bool `true` if id is set
@@ -82,5 +82,5 @@ class ReferencingArray implements ResolveInterface
     {
         return ($this->items !== null);
     }
-    
+
 }

--- a/src/ResolveInterface.php
+++ b/src/ResolveInterface.php
@@ -10,23 +10,22 @@ namespace yii\di;
 use Psr\Container\ContainerInterface;
 
 /**
- * Interface of references 
- * 
+ * Interface of references
+ *
  * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
  */
 interface ResolveInterface
 {
-    
+
     /**
      * Returns the actual value
      * @param ContainerInterface $container Container to use to resolve the reference
      */
     public function get(?ContainerInterface $container = null);
-    
+
     /**
      * Returns wether this is a valid reference
      * @return bool
      */
     public function isDefined();
-    
 }

--- a/src/ResolveInterface.php
+++ b/src/ResolveInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Interface of references 
+ * 
+ * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
+ */
+interface ResolveInterface
+{
+    
+    /**
+     * Returns the actual value
+     * @param ContainerInterface $container Container to use to resolve the reference
+     */
+    public function get(?ContainerInterface $container = null);
+    
+    /**
+     * Returns wether this is a valid reference
+     * @return bool
+     */
+    public function isDefined();
+    
+}

--- a/src/exceptions/InvalidArgumentException.php
+++ b/src/exceptions/InvalidArgumentException.php
@@ -16,4 +16,5 @@ use Psr\Container\ContainerExceptionInterface;
  */
 class InvalidArgumentException extends \InvalidArgumentException implements ContainerExceptionInterface
 {
+
 }

--- a/src/exceptions/InvalidArgumentException.php
+++ b/src/exceptions/InvalidArgumentException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\exceptions;
+
+use Psr\Container\ContainerExceptionInterface;
+
+/**
+ * Invalid argument used for a container related method call
+ *
+ * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ContainerExceptionInterface
+{
+}

--- a/tests/CallableReferenceTest.php
+++ b/tests/CallableReferenceTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\tests;
+
+use PHPUnit\Framework\TestCase;
+use yii\di\Reference;
+use yii\di\tests\code\EngineInterface;
+
+/**
+ * Description of ReferencingArrayTest
+ *
+ * @author Andreas Prucha, Abexto - Helicon Software Development <andreas.prucha@gmail.com>
+ */
+class CallableReferenceTest extends TestCase
+{
+    
+    public function testGet()
+    {
+        $container = new \yii\di\Container();
+        $callableRef = \yii\di\CallableReference::to(function($container)
+            {return ($container instanceof \Psr\Container\ContainerInterface) ? 'valid':'invalid';}
+        );
+        $this->assertEquals('valid', $callableRef->get($container));
+    }
+    
+}

--- a/tests/CallableReferenceTest.php
+++ b/tests/CallableReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link http://www.yiiframework.com/
  * @copyright Copyright (c) 2008 Yii Software LLC
@@ -18,14 +19,15 @@ use yii\di\tests\code\EngineInterface;
  */
 class CallableReferenceTest extends TestCase
 {
-    
+
     public function testGet()
     {
         $container = new \yii\di\Container();
-        $callableRef = \yii\di\CallableReference::to(function($container)
-            {return ($container instanceof \Psr\Container\ContainerInterface) ? 'valid':'invalid';}
+        $callableRef = \yii\di\CallableReference::to(function($container) {
+                    return ($container instanceof \Psr\Container\ContainerInterface) ? 'valid' : 'invalid';
+                }
         );
         $this->assertEquals('valid', $callableRef->get($container));
     }
-    
+
 }

--- a/tests/CallableReferenceTest.php
+++ b/tests/CallableReferenceTest.php
@@ -12,9 +12,9 @@ use yii\di\Reference;
 use yii\di\tests\code\EngineInterface;
 
 /**
- * Description of ReferencingArrayTest
+ * Tests for CallableReference
  *
- * @author Andreas Prucha, Abexto - Helicon Software Development <andreas.prucha@gmail.com>
+ * @author Andreas Prucha (Abexto - Helicon Software Development) <andreas.prucha@gmail.com>
  */
 class CallableReferenceTest extends TestCase
 {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -288,4 +288,20 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(EngineMarkOne::class, $engine);
         $this->assertSame($number, $engine->getNumer());
     }
+    
+    public function testClassConstructorWithArrayOfReferences()
+    {
+        $container = new Container();
+        $container->set('constructor_test', [
+            '__class' => code\PartCatalog::class,
+            '__construct()' => [\yii\di\ReferencingArray::items
+                (['markOne' => Reference::to(EngineMarkOne::class),
+                 'markTwo' => Reference::to(EngineMarkOne::class)])]
+        ]);
+
+        /** @var code\PartCatalog $object */
+        $object = $container->get('constructor_test');
+        $this->assertInstanceOf(EngineMarkOne::class, $object->engines['markOne']);
+        $this->assertInstanceOf(EngineMarkOne::class, $object->engines['markTwo']);
+    }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -296,12 +296,14 @@ class ContainerTest extends TestCase
             '__class' => code\PartCatalog::class,
             '__construct()' => [\yii\di\ReferencingArray::items
                 (['markOne' => Reference::to(EngineMarkOne::class),
-                 'markTwo' => Reference::to(EngineMarkOne::class)])]
+                 'markTwo' => Reference::to(EngineMarkOne::class)])],
+            'created' => \yii\di\CallableReference::to(function(){return new \DateTime();})
         ]);
 
         /** @var code\PartCatalog $object */
         $object = $container->get('constructor_test');
         $this->assertInstanceOf(EngineMarkOne::class, $object->engines['markOne']);
         $this->assertInstanceOf(EngineMarkOne::class, $object->engines['markTwo']);
+        $this->assertInstanceOf(\DateTime::class, $object->created);
     }
 }

--- a/tests/ReferencingArrayTest.php
+++ b/tests/ReferencingArrayTest.php
@@ -18,21 +18,21 @@ use yii\di\tests\code\EngineInterface;
  */
 class ReferencingArrayTest extends TestCase
 {
-    
+
     public function testGet()
     {
         $container = new \yii\di\Container();
         $container->set('m1', new code\EngineMarkOne());
         $container->set('m2', new code\EngineMarkTwo());
         $refArray = \yii\di\ReferencingArray::items([
-            'markOne' => Reference::to('m1'),
-            'markTwo' => Reference::to('m2'),
-            'devil' => 666]);
+                    'markOne' => Reference::to('m1'),
+                    'markTwo' => Reference::to('m2'),
+                    'devil' => 666]);
         $result = $refArray->get($container);
         $this->assertIsArray($result);
         $this->assertInstanceOf(code\EngineMarkOne::class, $result['markOne']);
         $this->assertInstanceOf(code\EngineMarkTwo::class, $result['markTwo']);
         $this->assertEquals(666, $result['devil']);
     }
-    
+
 }

--- a/tests/ReferencingArrayTest.php
+++ b/tests/ReferencingArrayTest.php
@@ -12,7 +12,7 @@ use yii\di\Reference;
 use yii\di\tests\code\EngineInterface;
 
 /**
- * Description of ReferencingArrayTest
+ * Tests for ReferencingArray
  *
  * @author Andreas Prucha, Abexto - Helicon Software Development <andreas.prucha@gmail.com>
  */

--- a/tests/ReferencingArrayTest.php
+++ b/tests/ReferencingArrayTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\di\tests;
+
+use PHPUnit\Framework\TestCase;
+use yii\di\Reference;
+use yii\di\tests\code\EngineInterface;
+
+/**
+ * Description of ReferencingArrayTest
+ *
+ * @author Andreas Prucha, Abexto - Helicon Software Development <andreas.prucha@gmail.com>
+ */
+class ReferencingArrayTest extends TestCase
+{
+    
+    public function testGet()
+    {
+        $container = new \yii\di\Container();
+        $container->set('m1', new code\EngineMarkOne());
+        $container->set('m2', new code\EngineMarkTwo());
+        $refArray = \yii\di\ReferencingArray::items([
+            'markOne' => Reference::to('m1'),
+            'markTwo' => Reference::to('m2'),
+            'devil' => 666]);
+        $result = $refArray->get($container);
+        $this->assertIsArray($result);
+        $this->assertInstanceOf(code\EngineMarkOne::class, $result['markOne']);
+        $this->assertInstanceOf(code\EngineMarkTwo::class, $result['markTwo']);
+        $this->assertEquals(666, $result['devil']);
+    }
+    
+}

--- a/tests/code/PartCatalog.php
+++ b/tests/code/PartCatalog.php
@@ -4,11 +4,13 @@ namespace yii\di\tests\code;
 
 class PartCatalog
 {
+
     public $engines = [];
     public $created = null;
-    
+
     public function __construct(array $engines)
     {
         $this->engines = $engines;
     }
+
 }

--- a/tests/code/PartCatalog.php
+++ b/tests/code/PartCatalog.php
@@ -8,14 +8,10 @@
 
 namespace yii\di\tests\code;
 
-/**
- * Description of PartCatalog
- *
- * @author Andreas Prucha, Abexto - Helicon Software Development <andreas.prucha@gmail.com>
- */
 class PartCatalog
 {
     public $engines = [];
+    public $created = null;
     
     public function __construct(array $engines)
     {

--- a/tests/code/PartCatalog.php
+++ b/tests/code/PartCatalog.php
@@ -1,11 +1,5 @@
 <?php
 
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
 namespace yii\di\tests\code;
 
 class PartCatalog

--- a/tests/code/PartCatalog.php
+++ b/tests/code/PartCatalog.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+namespace yii\di\tests\code;
+
+/**
+ * Description of PartCatalog
+ *
+ * @author Andreas Prucha, Abexto - Helicon Software Development <andreas.prucha@gmail.com>
+ */
+class PartCatalog
+{
+    public $engines = [];
+    
+    public function __construct(array $engines)
+    {
+        $this->engines = $engines;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #75 

Declares the interface ResolveInterface with the method get which is called by the container to resolve the reference.

all referencing objects can be resolved by `$theReference->get($theContainerToAsk);`

- `Reference` now implements this interface 
- `ReferencingArray` can be used if a constructor argument or 
  property requires an array containing references  which need to be resolved
- `CallableReference` is a special case. It just contains a callable which is called when container resolves 
  references. This can be used for function calls for constructor arguments or properties which are not valid at the time the container is configured by an configuration array (e.g. resolve aliased path)