### PR TITLE
Add conditional singletons

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -51,8 +51,7 @@ final class Container extends AbstractContainerConfigurator implements Container
         array $definitions = [],
         array $providers = [],
         ContainerInterface $rootContainer = null
-    )
-    {
+    ) {
         $this->setMultiple($definitions);
         $this->addProviders($providers);
         if ($rootContainer !== null) {
@@ -87,7 +86,7 @@ final class Container extends AbstractContainerConfigurator implements Container
     public function get($id, array $parameters = [])
     {
         $id = $this->getId($id);
-        $this->validateCache($id);
+        $this->invalidateCache($id);
         if (!isset($this->instances[$id])) {
             $this->instances[$id] = $this->build($id, $parameters);
         }
@@ -200,7 +199,7 @@ final class Container extends AbstractContainerConfigurator implements Container
         return $definition;
     }
 
-    private function validateCache($id): void
+    private function invalidateCache($id): void
     {
         if (isset($this->cacheConditions[$id])) {
             $condition = $this->cacheConditions[$id];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️

Conditional singletons. When the `__cacheCondition` equal true, the cached singleton instance will be returned, otherwise, the cache will be reset and a new instance will be returned 

Examples:
This is a session-dependent service. When a new session starts, a new instance of the `IdentityRepository` will be returned.  
```php
IdentityRepositoryInterface::class => [
        '__definition' => static function (ContainerInterface $container) {
            return $container->get(\Cycle\ORM\ORMInterface::class)->getRepository(\App\Entity\User::class);
        },
        '__cacheCondition' => function (ContainerInterface $container) {
                $currentSession = $container->get(SessionInterface::class);
                $lastSessionStorage = $container->get(\App\LastSessionStorage::class);
                $sameSession = ($currentSession->getId() === $lastSessionStorage->getSession()->getId());
                if (!$sameSession) {
                    $lastSessionStorage->setSession($currentSession);
                }

                return $sameSession;
            },
    ],
```
This is not a singleton service. Every time a new instance will be created.
```php
MyNotSingletonServiceInterface::class => [
    '__class' => IAmNotSingleton::class,
   '__cacheCondition' => false,
   '__construct()' => ['someParam']
]
```
