### PR TITLE
Fix prioritizing dependencies

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -89,11 +89,12 @@ final class Container extends AbstractContainerConfigurator implements Container
      */
     public function get($id)
     {
+        $id = $this->getId($id);
+
         if (!$this->has($id)) {
             throw new NotFoundException("No definition for $id");
         }
 
-        $id = $this->getId($id);
         if (!isset($this->instances[$id])) {
             $this->instances[$id] = $this->build($id);
         }

--- a/src/Container.php
+++ b/src/Container.php
@@ -38,6 +38,8 @@ final class Container extends AbstractContainerConfigurator implements Container
 
     private ?ContainerInterface $rootContainer = null;
 
+    private bool $strict;
+
     /**
      * Container constructor.
      *
@@ -51,8 +53,10 @@ final class Container extends AbstractContainerConfigurator implements Container
     public function __construct(
         array $definitions = [],
         array $providers = [],
-        ContainerInterface $rootContainer = null
+        ContainerInterface $rootContainer = null,
+        bool $strict = false
     ) {
+        $this->strict = $strict;
         $this->setMultiple($definitions);
         $this->addProviders($providers);
         if ($rootContainer !== null) {
@@ -68,7 +72,7 @@ final class Container extends AbstractContainerConfigurator implements Container
      */
     public function has($id): bool
     {
-        return isset($this->definitions[$id]) || class_exists($id);
+        return isset($this->definitions[$id]) || (!$this->strict && class_exists($id));
     }
 
     /**
@@ -85,6 +89,10 @@ final class Container extends AbstractContainerConfigurator implements Container
      */
     public function get($id)
     {
+        if (!$this->has($id)) {
+            throw new NotFoundException("No definition for $id");
+        }
+
         $id = $this->getId($id);
         if (!isset($this->instances[$id])) {
             $this->instances[$id] = $this->build($id);

--- a/tests/Unit/AbstractCompositePsrContainerTest.php
+++ b/tests/Unit/AbstractCompositePsrContainerTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Yiisoft\Di\Tests\Unit;
 
 use Psr\Container\ContainerInterface;
-use Yiisoft\Di\Container;
-use Yiisoft\Di\CompositeContainer;
 use Psr\Container\NotFoundExceptionInterface;
+use Yiisoft\Di\CompositeContainer;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\Tests\Support\Car;
 use Yiisoft\Di\Tests\Support\EngineInterface;
 use Yiisoft\Di\Tests\Support\EngineMarkOne;
 use Yiisoft\Di\Tests\Support\EngineMarkTwo;
@@ -70,5 +71,19 @@ abstract class AbstractCompositePsrContainerTest extends AbstractPsrContainerTes
         $compositeContainer->attach($containerOne);
         $compositeContainer->attach($containerTwo);
         $this->assertInstanceOf(EngineMarkTwo::class, $compositeContainer->get(EngineInterface::class));
+
+        $compositeContainer = new CompositeContainer();
+        $containerOne = new Container();
+        $containerTwo = new Container([EngineMarkOne::class => EngineMarkTwo::class], [], $compositeContainer, true);
+        $compositeContainer->attach($containerOne);
+        $compositeContainer->attach($containerTwo);
+        $this->assertInstanceOf(EngineMarkTwo::class, $compositeContainer->get(EngineMarkOne::class));
+
+        $compositeContainer = new CompositeContainer();
+        $containerOne = new Container([EngineInterface::class => EngineMarkTwo::class]);
+        $containerTwo = new Container([EngineInterface::class => EngineMarkOne::class], [], $compositeContainer);
+        $compositeContainer->attach($containerOne);
+        $compositeContainer->attach($containerTwo);
+        $this->assertInstanceOf(EngineMarkOne::class, $compositeContainer->get(Car::class)->getEngine());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | ❌

Based on the early #134.

> It fixes the following case:
> 
> ```
> $compositeContainer
>   $subContainer 1
>   $subContainer 2
>     MyClass => [ ... ]
> 
> $myClass = $compositeContainer->get(MyClass::class);
> ```
> 
> Currently we'll get new instance of MyClass without config applied because Yii DI container tries to instantiate a class in case it's not in the config.

© @samdark