### PR TITLE
Allow more complex function call based defitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ return [
         'propertyName' => 'value',
         'setX()' => [42],
     ],
-    'closure' => function(ContainerInterface $container) {
-        return new MyClass($container->get('db'));
-    },
-    'static_call' => [MyFactory::class, 'create'],
+    'closure' => fn (SomeFactory $factory) => $factory->create('args'),
+    'static_call_preferred' => fn () => MyFactory::create('args'),
+    'static_call_supported' => [MyFactory::class, 'create'],
     'object' => new MyClass(),
 ];
 ```

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,11 @@
         "infection/infection": "^0.17.0",
         "phan/phan": "^3.0",
         "phpunit/phpunit": "^9.3",
+        "yiisoft/injector": "^1.0@dev",
         "league/container": "^3.2"
     },
     "suggest": {
+        "yiisoft/injector": "^1.0@dev",
         "phpbench/phpbench": "To run benchmarks."
     },
     "provide": {

--- a/src/Container.php
+++ b/src/Container.php
@@ -54,6 +54,9 @@ final class Container extends AbstractContainerConfigurator implements Container
         ContainerInterface $rootContainer = null
     ) {
         $this->setMultiple($definitions);
+        if (!$this->has(ContainerInterface::class)) {
+            $this->set(ContainerInterface::class, $rootContainer ?? $this);
+        }
         $this->addProviders($providers);
         if ($rootContainer !== null) {
             $this->delegateLookup($rootContainer);

--- a/tests/Support/CarFactory.php
+++ b/tests/Support/CarFactory.php
@@ -17,10 +17,13 @@ class CarFactory
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
-    public static function create(ContainerInterface $container): Car
+    public static function create(EngineInterface $engine): Car
     {
-        /** @var EngineInterface $engine */
-        $engine = $container->get('engine');
         return new Car($engine);
+    }
+
+    public function createByEngineName(EngineFactory $factory, $name): Car
+    {
+        return new Car($factory->createByName($name));
     }
 }

--- a/tests/Support/EngineFactory.php
+++ b/tests/Support/EngineFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Di\Tests\Support;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * EngineFactory
+ */
+class EngineFactory
+{
+    private ContainerInterface $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function createByName(string $name = null): EngineInterface
+    {
+        if ($name === EngineMarkOne::NAME) {
+            return $this->container->get(EngineMarkOne::class);
+        }
+        if ($name === EngineMarkTwo::NAME) {
+            return $this->container->get(EngineMarkTwo::class);
+        }
+
+        throw new \Exception('unknown engine name: ' . $name);
+    }
+
+    public static function createDefault(): EngineInterface
+    {
+        return new EngineMarkOne();
+    }
+}

--- a/tests/Support/EngineMarkOne.php
+++ b/tests/Support/EngineMarkOne.php
@@ -10,8 +10,14 @@ namespace Yiisoft\Di\Tests\Support;
 class EngineMarkOne implements EngineInterface
 {
     public const NAME = 'Mark One';
+    public const NUMBER = 1;
 
     private int $number;
+
+    public function __construct(int $number = self::NUMBER)
+    {
+        $this->number = $number;
+    }
 
     public function getName(): string
     {

--- a/tests/Support/EngineMarkTwo.php
+++ b/tests/Support/EngineMarkTwo.php
@@ -10,8 +10,14 @@ namespace Yiisoft\Di\Tests\Support;
 class EngineMarkTwo implements EngineInterface
 {
     public const NAME = 'Mark Two';
+    public const NUMBER = 2;
 
     private int $number;
+
+    public function __construct(int $number = self::NUMBER)
+    {
+        $this->number = $number;
+    }
 
     public function getName(): string
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #148 

Add use of injector to allow more complex definitions.
See https://github.com/yiisoft/factory/pull/35 for examples.

Also add `ContainerInterface` definition in container by default
(but it still can be redefined).

Also extracted out `ReferenceTest` from huge `ContainerTest` which can be split up even more later.

This PR requires https://github.com/yiisoft/factory/pull/35 for tests to pass.