### PR TITLE
Add getInstances and setInstances AbstractContainerConfigurator

### DIFF
--- a/src/AbstractContainerConfigurator.php
+++ b/src/AbstractContainerConfigurator.php
@@ -22,4 +22,14 @@ abstract class AbstractContainerConfigurator
     {
         throw new \RuntimeException("Method 'delegateLookup' does not exist.");
     }
+
+    protected function getInstances(): array
+    {
+        throw new \RuntimeException("Method 'getInstances' does not exist.");
+    }
+
+    protected function setInstances(array $instances, bool $merge = false): void
+    {
+        throw new \RuntimeException("Method 'setInstances' does not exist.");
+    }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -31,7 +31,7 @@ final class Container extends AbstractContainerConfigurator implements Container
     private array $building = [];
 
     /**
-     * @var object[]
+     * @var object[]|null[]
      */
     private array $instances = [];
 
@@ -138,7 +138,7 @@ final class Container extends AbstractContainerConfigurator implements Container
 
     /**
      * Returns the currently created instances.
-     * @return object[]
+     * @return object[]|null[]
      */
     protected function getInstances(): array
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -137,6 +137,25 @@ final class Container extends AbstractContainerConfigurator implements Container
     }
 
     /**
+     * Returns the currently created instances.
+     * @return object[]
+     */
+    protected function getInstances(): array
+    {
+        return $this->instances;
+    }
+
+    /**
+     * Replaces instances.
+     * @param object[]|null[] $instances
+     * @param bool $merge specifies to install instances or merge with existing ones.
+     */
+    protected function setInstances(array $instances, bool $merge = false): void
+    {
+        $this->instances = $merge ? \array_merge($this->instances, $instances) : $instances;
+    }
+
+    /**
      * Creates new instance by either interface name or alias.
      *
      * @param string $id The interface or an alias name that was previously registered.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

This additional functionality allows for non-standard applications to interfere with the work of **Yiisoft\Di\Container**. Now there is a **set** method that allows you to interfere with the work of **Yiisoft\Di\Container**, so this new functionality does not threaten anything bad.

```php
class TestClass1
{
    public function __construct()
    {
        echo "\n*** Create TestClass1 ***\n\n";
    }
}

class TestClass2
{
    public function __construct()
    {
        echo "\n*** Create TestClass2 ***\n\n";
    }
}

class TestContainerConfigurator extends Yiisoft\Di\AbstractContainerConfigurator
{
    private array $ids;

    public function __construct(array $ids)
    {
        $this->ids = $ids;
    }

    public function reset(Container $container): void
    {
        $container->setInstances(\array_fill_keys($this->ids, null), true);
    }
}

$config = [
    TestClass1::class => TestClass1::class,
    TestClass2::class => TestClass2::class,
    TestContainerConfigurator::class => [
        '__construct()' => [[
            TestClass2::class,
        ]],
    ],
];
$providers = [];
$container = new Container($config, $providers);

var_dump($container->get(TestClass1::class));
var_dump($container->get(TestClass2::class));
echo "\n=== Next Request ===\n\n";
$container->get(TestContainerConfigurator::class)->reset($container);
var_dump($container->get(TestClass1::class));
var_dump($container->get(TestClass2::class));
```

We get the following output:
```
*** Create TestClass1 ***

object(TestClass1)#8 (0) {
}

*** Create TestClass2 ***

object(TestClass2)#9 (0) {
}

=== Next Request ===

object(TestClass1)#8 (0) {
}

*** Create TestClass2 ***

object(TestClass2)#4 (0) {
}
```

This functionality may help to avoid the introduction into a classic php web application of the code necessary for the application to work under conditions of multiple requests (such as RoadRunner), since there will be no need to clear the data after processing the request.