### PR TITLE
Fix `CircularReference` to `ContainerInterface`

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -149,6 +149,9 @@ final class Container extends AbstractContainerConfigurator implements Container
     private function build(string $id)
     {
         if (isset($this->building[$id])) {
+            if ($id === ContainerInterface::class) {
+                return $this;
+            }
             throw new CircularReferenceException(sprintf(
                 'Circular reference to "%s" detected while building: %s',
                 $id,

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -121,6 +121,15 @@ class ContainerTest extends TestCase
         $container->get(Chicken::class);
     }
 
+    public function testCircularContainerInterface(): void
+    {
+        $container = new Container([
+            ContainerInterface::class => fn (ContainerInterface $container) => $container,
+        ]);
+
+        $this->assertSame($container, $container->get(ContainerInterface::class));
+    }
+
     public function testClassSimple(): void
     {
         $container = new Container([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
