### PR TITLE
Fix circular reference when nested container defined

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -60,6 +60,8 @@ final class Container extends AbstractContainerConfigurator implements Container
         if ($rootContainer !== null) {
             $this->delegateLookup($rootContainer);
         }
+        # Prevent circular reference to ContainerInterface
+        $this->get(ContainerInterface::class);
     }
 
     /**


### PR DESCRIPTION
First of all any closure definition for `ContainerInterface` like the
following IS the circular reference! Cause `ContainerInterface` is defined
using itself.

```php
    ContainerInterface::class => static function (ContainerInterface $container) {
        return $container;
    }
```

Fix introduced here:
https://github.com/yiisoft/di/blob/7fc72e868361e4104b5a5d238f023c7716d06d0f/src/Container.php#L152-L154
is incomplete. It solves the problem only for `$container->get(ContainerInterface::class)`

But `CircularReferenceException` still happens when resolving any other definition requiring
`ContainerInterface`.
For example:

```php
    EngineInterface::class => fn (EngineFactory $factory) => $factory->create()
```

`EngineInterface` needs `Injector` needs `ContainerInterface` needs `ContainerInterface`.

I could not find better solution then resolve `ContainerInterface` preventively.
This solution is simple and it works. But still looking for better ideas.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
