### PR TITLE
Fix circular reference again

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -14,6 +14,7 @@ use Yiisoft\Factory\Exceptions\NotFoundException;
 use Yiisoft\Factory\Exceptions\NotInstantiableException;
 use Yiisoft\Factory\Definitions\Normalizer;
 use Yiisoft\Factory\Definitions\ArrayDefinition;
+use Yiisoft\Injector\Injector;
 
 /**
  * Container implements a [dependency injection](http://en.wikipedia.org/wiki/Dependency_injection) container.
@@ -56,6 +57,7 @@ final class Container extends AbstractContainerConfigurator implements Container
         if (!$this->has(ContainerInterface::class)) {
             $this->set(ContainerInterface::class, $rootContainer ?? $this);
         }
+
         $this->addProviders($providers);
         if ($rootContainer !== null) {
             $this->delegateLookup($rootContainer);
@@ -150,6 +152,9 @@ final class Container extends AbstractContainerConfigurator implements Container
      */
     private function build(string $id)
     {
+        if ($id === Injector::class) {
+            return new Injector($this);
+        }
         if (isset($this->building[$id])) {
             if ($id === ContainerInterface::class) {
                 return $this;

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -12,6 +12,7 @@ use Yiisoft\Di\Container;
 use Yiisoft\Factory\Exceptions\CircularReferenceException;
 use Yiisoft\Factory\Exceptions\InvalidConfigException;
 use Yiisoft\Factory\Exceptions\NotFoundException;
+use Yiisoft\Di\Support\ServiceProvider;
 use Yiisoft\Di\Tests\Support\A;
 use Yiisoft\Di\Tests\Support\B;
 use Yiisoft\Di\Tests\Support\Car;
@@ -169,7 +170,7 @@ class ContainerTest extends TestCase
             'container' => fn (ContainerInterface $container) => $container,
         ]);
 
-        ### Order is crucial! Problem appears when 'new-container' is resolveed first
+        ### The order is crucial! Problem can appear when resolving 'new-container' first
         $newcontainer = $container->get('new-container');
         $this->assertNotSame($container, $newcontainer);
         $this->assertSame($newcontainer, $container->get(ContainerInterface::class));
@@ -177,6 +178,57 @@ class ContainerTest extends TestCase
         $this->assertInstanceOf(EngineMarkOne::class, $newcontainer->get(EngineInterface::class));
         $this->expectException(NotFoundException::class);
         $this->assertInstanceOf(EngineMarkOne::class, $container->get(EngineInterface::class));
+    }
+
+    public function testNestedContainerInProvider(): void
+    {
+        $container = new Container(
+            [],
+            [
+                new class() extends ServiceProvider {
+                    public function register(Container $container): void
+                    {
+                        $container->set(ContainerInterface::class, static function (ContainerInterface $container) {
+                            return $container->get('new-container');
+                        });
+                    }
+                },
+                new class() extends ServiceProvider {
+                    public function register(Container $container): void
+                    {
+                        $container->set('new-container', fn (ContainerInterface $container) => new Container([
+                            EngineInterface::class => EngineMarkOne::class,
+                        ], [], $container));
+                    }
+                },
+                new class() extends ServiceProvider {
+                    public function register(Container $container): void
+                    {
+                        $container->set('container', fn (ContainerInterface $container) => $container);
+                    }
+                },
+                new class() extends ServiceProvider {
+                    public function register(Container $container): void
+                    {
+                        $container->set(B::class, function () {
+                            throw new \RuntimeException();
+                        });
+                    }
+                },
+            ],
+        );
+
+        ### The order is crucial! Problem can appear when resolving 'new-container' first
+        $newcontainer = $container->get('new-container');
+        $this->assertNotSame($container, $newcontainer);
+        $this->assertSame($newcontainer, $container->get(ContainerInterface::class));
+        $this->assertSame($newcontainer, $container->get('container'));
+        $this->assertInstanceOf(EngineMarkOne::class, $newcontainer->get(EngineInterface::class));
+        $this->assertFalse($container->has(EngineInterface::class));
+        $this->assertTrue($newcontainer->has(EngineInterface::class));
+
+        $this->expectException(\RuntimeException::class);
+        $container->get(B::class);
     }
 
     public function testClassSimple(): void


### PR DESCRIPTION
Fixes `yiisoft/app`
Doesn't need fix in factory https://github.com/yiisoft/factory/pull/45
Extends and substitutes test provided in #162

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/factory/pull/45, #161, #162 
