### PR TITLE
Add default definitions

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -53,14 +53,20 @@ final class Container extends AbstractContainerConfigurator implements Container
         ContainerInterface $rootContainer = null
     ) {
         $this->delegateLookup($rootContainer);
+        $this->setDefaultDefinitions();
         $this->setMultiple($definitions);
-        if (!$this->has(ContainerInterface::class)) {
-            $this->set(ContainerInterface::class, $rootContainer ?? $this);
-        }
         $this->addProviders($providers);
 
         # Prevent circular reference to ContainerInterface
         $this->get(ContainerInterface::class);
+    }
+
+    private function setDefaultDefinitions(): void
+    {
+        $this->definitions = [
+            ContainerInterface::class => $this->rootContainer ?? $this,
+            Injector::class => new Injector($this),
+        ];
     }
 
     /**
@@ -152,9 +158,6 @@ final class Container extends AbstractContainerConfigurator implements Container
      */
     private function build(string $id)
     {
-        if ($id === Injector::class) {
-            return new Injector($this);
-        }
         if (isset($this->building[$id])) {
             if ($id === ContainerInterface::class) {
                 return $this;

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -448,6 +448,18 @@ class ContainerTest extends TestCase
         $container->get(TreeItem::class);
     }
 
+    public function testChangeInjector(): void
+    {
+        $container = new Container([
+            Injector::class => new Injector(new Container([
+                EngineInterface::class => EngineMarkOne::class,
+            ])),
+            'car' => fn (EngineInterface $engine) => new Car($engine),
+        ]);
+
+        $this->assertInstanceOf(EngineMarkOne::class, $container->get('car')->getEngine());
+    }
+
     public function testCallable(): void
     {
         $container = new Container([


### PR DESCRIPTION
Improve code style.
Make default definitions explicit and collected in single place.
Allow change `Injector` used in the container (with test).

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

