### PR TITLE
add more test

### DIFF
--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -683,6 +683,29 @@ class ContainerTest extends TestCase
         $this->assertSame($color, $car->getColor());
     }
 
+    public function testCallableArrayValueInConstructor()
+    {
+        $array = [
+            [EngineMarkTwo::class, 'getNumber']
+        ];
+        $container = new Container(
+            [
+                EngineInterface::class => EngineMarkOne::class,
+                Car::class => [
+                    '__class' => Car::class,
+                    '__construct()' => [
+                        Reference::to(EngineInterface::class),
+                        $array
+                    ]
+                ]
+            ]
+        );
+
+        /** @var Car $object */
+        $object = $container->get(Car::class);
+        $this->assertSame($array, $object->getMoreEngines());
+    }
+
     public function testSameInstance(): void
     {
         $container = new Container([


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    |
| New feature?  |
| Breaks BC?    |
| Fixed issues  |

EventDispatcherProvider receives invalid data, since an array with callable is passed to it, and the current implementation of the factory enters the array and breaks it.

should be
```php
Array
(
    [Yiisoft\Yii\Cycle\Event\AfterMigrate] => Array
        (
            [0] => Array
                (
                    [0] => Yiisoft\Yii\Cycle\Listener\MigrationListener
                    [1] => onAfterMigrate
                )

        )

)
```

received
```php
Array
(
    [Yiisoft\Yii\Cycle\Event\AfterMigrate] => Array
        (
            [0] => 
        )

)
```