### PR TITLE
Psalm: fix errors + improve annotations for Container::get()

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -105,11 +105,11 @@ final class Container extends AbstractContainerConfigurator implements Container
      * @throws NotFoundException
      * @throws NotInstantiableException
      *
-     * @return object An instance of the requested interface.
+     * @return mixed|object An instance of the requested interface.
      *
      * @psalm-template T
      * @psalm-param string|class-string<T> $id
-     * @psalm-return ($id is class-string ? T : object)
+     * @psalm-return ($id is class-string ? T : mixed)
      */
     public function get($id)
     {
@@ -181,7 +181,7 @@ final class Container extends AbstractContainerConfigurator implements Container
      * @throws InvalidConfigException
      * @throws NotFoundException
      *
-     * @return object New built instance of the specified class.
+     * @return mixed|object New built instance of the specified class.
      *
      * @internal
      */

--- a/src/Container.php
+++ b/src/Container.php
@@ -106,6 +106,10 @@ final class Container extends AbstractContainerConfigurator implements Container
      * @throws NotInstantiableException
      *
      * @return object An instance of the requested interface.
+     *
+     * @psalm-template T
+     * @psalm-param string|class-string<T> $id
+     * @psalm-return ($id is class-string ? T : object)
      */
     public function get($id)
     {

--- a/src/Container.php
+++ b/src/Container.php
@@ -307,6 +307,9 @@ final class Container extends AbstractContainerConfigurator implements Container
         return $provider;
     }
 
+    /**
+     * @param mixed $variable
+     */
     private function getVariableType($variable): string
     {
         if (is_object($variable)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

- Fixed psalm errors.
- Added annotations for `Contaner::get()` which allow the psalm to understand what the method returns.

For example:

```php
$handler = $container->get(ErrorHandler::class);
```

Psalm will be understand that `$handler` is instance of `ErrorHandler`.
