### PR TITLE
Simplify type hinting in phpdoc container constructor

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -66,8 +66,7 @@ final class Container extends AbstractContainerConfigurator implements Container
      * Container constructor.
      *
      * @param array $definitions Definitions to put into container.
-     * @param array $providers Service providers
-     * to get definitions from.
+     * @param array $providers Service providers to get definitions from.
      * @param ContainerInterface|null $rootContainer Root container to delegate
      * lookup to when resolving dependencies. If provided the current container
      * is no longer queried for dependencies.

--- a/src/Container.php
+++ b/src/Container.php
@@ -66,7 +66,7 @@ final class Container extends AbstractContainerConfigurator implements Container
      * Container constructor.
      *
      * @param array $definitions Definitions to put into container.
-     * @param ServiceProviderInterface[]|string[] $providers Service providers
+     * @param array $providers Service providers
      * to get definitions from.
      * @param ContainerInterface|null $rootContainer Root container to delegate
      * lookup to when resolving dependencies. If provided the current container


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Almost always container created with custom array. If setted specific type for definitions and providers, then psalm show errors.

Example in `app`:

![image](https://user-images.githubusercontent.com/525501/121860745-d5c43880-cd01-11eb-8665-a03c0aa7abec.png)
