### PR TITLE
Use AbstractContainerConfigurator instead of Container

### DIFF
--- a/src/Contracts/ServiceProviderInterface.php
+++ b/src/Contracts/ServiceProviderInterface.php
@@ -55,7 +55,7 @@ interface ServiceProviderInterface
      * This method may be called multiple times with different container objects,
      * or multiple times with the same object.
      *
-     * @param AbstractContainerConfigurator $container the container configurator which registers the services.
+     * @param AbstractContainerConfigurator $containerConfigurator the container configurator which registers the services.
      */
-    public function register(AbstractContainerConfigurator $container): void;
+    public function register(AbstractContainerConfigurator $containerConfigurator): void;
 }

--- a/src/Contracts/ServiceProviderInterface.php
+++ b/src/Contracts/ServiceProviderInterface.php
@@ -19,7 +19,7 @@ use Yiisoft\Di\Container;
  * ```php
  * class CarProvider implements ServiceProviderInterface
  * {
- *    public function register(Container $container): void
+ *    public function register(AbstractContainerConfigurator $container): void
  *    {
  *        $this->registerDependencies($container);
  *        $this->registerService($container);
@@ -55,7 +55,7 @@ interface ServiceProviderInterface
      * This method may be called multiple times with different container objects,
      * or multiple times with the same object.
      *
-     * @param Container $container the container in which to register the services.
+     * @param AbstractContainerConfigurator $container the container configurator which registeres the services.
      */
-    public function register(Container $container): void;
+    public function register(AbstractContainerConfigurator $container): void;
 }

--- a/src/Contracts/ServiceProviderInterface.php
+++ b/src/Contracts/ServiceProviderInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Di\Contracts;
 
-use Yiisoft\Di\Container;
+use Yiisoft\Di\AbstractContainerConfigurator;
 
 /**
  * Represents a component responsible for class registration in the Container.
@@ -55,7 +55,7 @@ interface ServiceProviderInterface
      * This method may be called multiple times with different container objects,
      * or multiple times with the same object.
      *
-     * @param AbstractContainerConfigurator $container the container configurator which registeres the services.
+     * @param AbstractContainerConfigurator $container the container configurator which registers the services.
      */
     public function register(AbstractContainerConfigurator $container): void;
 }

--- a/src/Support/ServiceProvider.php
+++ b/src/Support/ServiceProvider.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Yiisoft\Di\Support;
 
 use Yiisoft\Di\AbstractContainerConfigurator;
-use Yiisoft\Di\Container;
 use Yiisoft\Di\Contracts\ServiceProviderInterface;
 
 abstract class ServiceProvider extends AbstractContainerConfigurator implements ServiceProviderInterface
 {
-    abstract public function register(Container $container): void;
+    abstract public function register(AbstractContainerConfigurator $containerConfigurator): void;
 }

--- a/tests/Support/CarDeferredProvider.php
+++ b/tests/Support/CarDeferredProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Di\Tests\Support;
 
-use Yiisoft\Di\Container;
+use Yiisoft\Di\AbstractContainerConfigurator;
 use Yiisoft\Di\Support\DeferredServiceProvider;
 
 class CarDeferredProvider extends DeferredServiceProvider
@@ -17,10 +17,10 @@ class CarDeferredProvider extends DeferredServiceProvider
         ];
     }
 
-    public function register(Container $container): void
+    public function register(AbstractContainerConfigurator $containerConfigurator): void
     {
-        $container->set('car', ['class' => Car::class]);
-        $container->set('car-factory', CarFactory::class);
-        $container->set(EngineInterface::class, EngineMarkOne::class);
+        $containerConfigurator->set('car', ['class' => Car::class]);
+        $containerConfigurator->set('car-factory', CarFactory::class);
+        $containerConfigurator->set(EngineInterface::class, EngineMarkOne::class);
     }
 }

--- a/tests/Support/CarProvider.php
+++ b/tests/Support/CarProvider.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Yiisoft\Di\Tests\Support;
 
-use Yiisoft\Di\Container;
+use Yiisoft\Di\AbstractContainerConfigurator;
 use Yiisoft\Di\Support\ServiceProvider;
 
 class CarProvider extends ServiceProvider
 {
-    public function register(Container $container): void
+    public function register(AbstractContainerConfigurator $containerConfigurator): void
     {
-        $container->set('car', Car::class);
-        $container->set(EngineInterface::class, EngineMarkOne::class);
+        $containerConfigurator->set('car', Car::class);
+        $containerConfigurator->set(EngineInterface::class, EngineMarkOne::class);
     }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -192,9 +192,9 @@ class ContainerTest extends TestCase
             [],
             [
                 new class() extends ServiceProvider {
-                    public function register(Container $container): void
+                    public function register(AbstractContainerConfigurator $containerConfigurator): void
                     {
-                        $container->set(
+                        $containerConfigurator->set(
                             ContainerInterface::class,
                             static function (ContainerInterface $container) {
                                 return $container->get('new-container');
@@ -203,9 +203,9 @@ class ContainerTest extends TestCase
                     }
                 },
                 new class() extends ServiceProvider {
-                    public function register(Container $container): void
+                    public function register(AbstractContainerConfigurator $containerConfigurator): void
                     {
-                        $container->set(
+                        $containerConfigurator->set(
                             'new-container',
                             fn (ContainerInterface $container) => new Container(
                                 [
@@ -213,21 +213,21 @@ class ContainerTest extends TestCase
                                 ],
                                 [],
                                 [],
-                                $container
+                                $containerConfigurator
                             )
                         );
                     }
                 },
                 new class() extends ServiceProvider {
-                    public function register(Container $container): void
+                    public function register(AbstractContainerConfigurator $containerConfigurator): void
                     {
-                        $container->set('container', fn (ContainerInterface $container) => $container);
+                        $containerConfigurator->set('container', fn (ContainerInterface $container) => $containerConfigurator);
                     }
                 },
                 new class() extends ServiceProvider {
-                    public function register(Container $container): void
+                    public function register(AbstractContainerConfigurator $containerConfigurator): void
                     {
-                        $container->set(
+                        $containerConfigurator->set(
                             B::class,
                             function () {
                                 throw new \RuntimeException();
@@ -1400,16 +1400,16 @@ class ContainerTest extends TestCase
     public function testCircularReferenceExceptionWhileResolvingProviders(): void
     {
         $provider = new class() extends ServiceProvider {
-            public function register(Container $container): void
+            public function register(AbstractContainerConfigurator $containerConfigurator): void
             {
-                $container->set(
+                $containerConfigurator->set(
                     ContainerInterface::class,
                     static function (ContainerInterface $container) {
                         // E.g. wrapping container with proxy class
                         return $container;
                     }
                 );
-                $container->get(B::class);
+                $containerConfigurator->get(B::class);
             }
         };
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

This allows to use another implementation of Yiisoft Container or any bridges to connect Yiisoft Container with another containers
