### PR TITLE
Improve containers types to use iterable objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0 under development
 
-- Chg #299: Improve containers types to use iterable objects (@xepozz)
+- Chg #299: Improve types to use iterable objects (@xepozz)
 
 ## 1.2.1 December 23, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Yii Dependency Injection Change Log
 
-## 1.2.2 under development
+## 2.0.0 under development
 
-- no changes in this release.
+- Chg #299: Improve containers types to use iterable objects (@xepozz)
 
 ## 1.2.1 December 23, 2022
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Di;
 use Closure;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
+use Traversable;
 use Yiisoft\Definitions\ArrayDefinition;
 use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
@@ -428,9 +429,9 @@ final class Container implements ContainerInterface
                 }
             }
         }
-        /** @psalm-var array<string, list<string>> $tags */
+        /** @psalm-var array<string, list<string>>|Traversable $tags */
 
-        $this->tags = $tags;
+        $this->tags = $tags instanceof Traversable ? iterator_to_array($tags) : $tags ;
     }
 
     /**
@@ -439,7 +440,14 @@ final class Container implements ContainerInterface
     private function setDefinitionTags(string $id, iterable $tags): void
     {
         foreach ($tags as $tag) {
-            if (!isset($this->tags[$tag]) || !in_array($id, $this->tags[$tag], true)) {
+            if (!isset($this->tags[$tag])) {
+                $this->tags[$tag] = [$id];
+                continue;
+            }
+
+            $tags = $this->tags[$tag];
+            $tags = $tags instanceof Traversable ? iterator_to_array($tags) : $tags;
+            if (!in_array($id, $tags, true)) {
                 $this->tags[$tag][] = $id;
             }
         }

--- a/src/Container.php
+++ b/src/Container.php
@@ -230,11 +230,11 @@ final class Container implements ContainerInterface
     /**
      * Sets multiple definitions at once.
      *
-     * @param array $config Definitions indexed by their IDs.
+     * @param iterable $config Definitions indexed by their IDs.
      *
      * @throws InvalidConfigException
      */
-    private function addDefinitions(array $config): void
+    private function addDefinitions(iterable $config): void
     {
         /** @var mixed $definition */
         foreach ($config as $id => $definition) {
@@ -258,11 +258,11 @@ final class Container implements ContainerInterface
      * Each delegate must is a callable in format "function (ContainerInterface $container): ContainerInterface".
      * The container instance returned is used in case a service can not be found in primary container.
      *
-     * @param array $delegates
+     * @param iterable $delegates
      *
      * @throws InvalidConfigException
      */
-    private function setDelegates(array $delegates): void
+    private function setDelegates(iterable $delegates): void
     {
         $this->delegates = new CompositeContainer();
         foreach ($delegates as $delegate) {
@@ -327,7 +327,7 @@ final class Container implements ContainerInterface
     /**
      * @throws InvalidConfigException
      */
-    private function validateMeta(array $meta): void
+    private function validateMeta(iterable $meta): void
     {
         /** @var mixed $value */
         foreach ($meta as $key => $value) {
@@ -359,10 +359,10 @@ final class Container implements ContainerInterface
      */
     private function validateDefinitionTags($tags): void
     {
-        if (!is_array($tags)) {
+        if (!is_iterable($tags)) {
             throw new InvalidConfigException(
                 sprintf(
-                    'Invalid definition: tags should be array of strings, %s given.',
+                    'Invalid definition: tags should be iterable object or array of strings, %s given.',
                     $this->getVariableType($tags)
                 )
             );
@@ -395,7 +395,7 @@ final class Container implements ContainerInterface
     /**
      * @throws InvalidConfigException
      */
-    private function setTags(array $tags): void
+    private function setTags(iterable $tags): void
     {
         if ($this->validate) {
             foreach ($tags as $tag => $services) {
@@ -407,10 +407,10 @@ final class Container implements ContainerInterface
                         )
                     );
                 }
-                if (!is_array($services)) {
+                if (!is_iterable($services)) {
                     throw new InvalidConfigException(
                         sprintf(
-                            'Invalid tags configuration: tag should contain array of service IDs, %s given.',
+                            'Invalid tags configuration: tag should be iterable object or array of service IDs, %s given.',
                             $this->getVariableType($services)
                         )
                     );
@@ -436,7 +436,7 @@ final class Container implements ContainerInterface
     /**
      * @psalm-param string[] $tags
      */
-    private function setDefinitionTags(string $id, array $tags): void
+    private function setDefinitionTags(string $id, iterable $tags): void
     {
         foreach ($tags as $tag) {
             if (!isset($this->tags[$tag]) || !in_array($id, $this->tags[$tag], true)) {
@@ -545,7 +545,7 @@ final class Container implements ContainerInterface
      * @throws CircularReferenceException
      * @throws InvalidConfigException
      */
-    private function addProviders(array $providers): void
+    private function addProviders(iterable $providers): void
     {
         $extensions = [];
         /** @var mixed $provider */

--- a/src/Container.php
+++ b/src/Container.php
@@ -366,7 +366,7 @@ final class Container implements ContainerInterface
         if (!is_iterable($tags)) {
             throw new InvalidConfigException(
                 sprintf(
-                    'Invalid definition: tags should be iterable object or array of strings, %s given.',
+                    'Invalid definition: tags should be either iterable or array of strings, %s given.',
                     $this->getVariableType($tags)
                 )
             );
@@ -414,7 +414,7 @@ final class Container implements ContainerInterface
                 if (!is_iterable($services)) {
                     throw new InvalidConfigException(
                         sprintf(
-                            'Invalid tags configuration: tag should be iterable object or array of service IDs, %s given.',
+                            'Invalid tags configuration: tag should be either iterable or array of service IDs, %s given.',
                             $this->getVariableType($services)
                         )
                     );

--- a/src/Container.php
+++ b/src/Container.php
@@ -60,7 +60,7 @@ final class Container implements ContainerInterface
 
     /**
      * @var array Tagged service IDs. The structure is `['tagID' => ['service1', 'service2']]`.
-     * @psalm-var array<string, list<string>>
+     * @psalm-var array<string, iterable<string>>
      */
     private array $tags;
 
@@ -238,6 +238,7 @@ final class Container implements ContainerInterface
     private function addDefinitions(iterable $config): void
     {
         /** @var mixed $definition */
+        /** @psalm-suppress MixedAssignment */
         foreach ($config as $id => $definition) {
             if ($this->validate && !is_string($id)) {
                 throw new InvalidConfigException(
@@ -247,8 +248,8 @@ final class Container implements ContainerInterface
                     )
                 );
             }
-            /** @var string $id */
 
+            $id = (string) $id;
             $this->addDefinition($id, $definition);
         }
     }
@@ -331,7 +332,9 @@ final class Container implements ContainerInterface
     private function validateMeta(iterable $meta): void
     {
         /** @var mixed $value */
+        /** @psalm-suppress MixedAssignment */
         foreach ($meta as $key => $value) {
+            $key = (string)$key;
             if (!in_array($key, self::ALLOWED_META, true)) {
                 throw new InvalidConfigException(
                     sprintf(
@@ -404,7 +407,7 @@ final class Container implements ContainerInterface
                     throw new InvalidConfigException(
                         sprintf(
                             'Invalid tags configuration: tag should be string, %s given.',
-                            $tag
+                            $this->getVariableType($tag)
                         )
                     );
                 }
@@ -429,9 +432,9 @@ final class Container implements ContainerInterface
                 }
             }
         }
-        /** @psalm-var array<string, list<string>>|Traversable $tags */
+        /** @psalm-var iterable<string, iterable<string>> $tags */
 
-        $this->tags = $tags instanceof Traversable ? iterator_to_array($tags) : $tags ;
+        $this->tags = $tags instanceof Traversable ? iterator_to_array($tags, true) : $tags ;
     }
 
     /**
@@ -446,8 +449,9 @@ final class Container implements ContainerInterface
             }
 
             $tags = $this->tags[$tag];
-            $tags = $tags instanceof Traversable ? iterator_to_array($tags) : $tags;
+            $tags = $tags instanceof Traversable ? iterator_to_array($tags, true) : $tags;
             if (!in_array($id, $tags, true)) {
+                /** @psalm-suppress PossiblyInvalidArrayAssignment */
                 $this->tags[$tag][] = $id;
             }
         }

--- a/src/Container.php
+++ b/src/Container.php
@@ -361,7 +361,7 @@ final class Container implements ContainerInterface
             throw new InvalidConfigException(
                 sprintf(
                     'Invalid definition: tags should be either iterable or array of strings, %s given.',
-                    $this->getVariableType($tags)
+                    get_debug_type($tags)
                 )
             );
         }

--- a/src/ContainerConfig.php
+++ b/src/ContainerConfig.php
@@ -9,11 +9,11 @@ namespace Yiisoft\Di;
  */
 final class ContainerConfig implements ContainerConfigInterface
 {
-    private array $definitions = [];
-    private array $providers = [];
-    private array $tags = [];
+    private iterable $definitions = [];
+    private iterable $providers = [];
+    private iterable $tags = [];
     private bool $validate = true;
-    private array $delegates = [];
+    private iterable $delegates = [];
     private bool $useStrictMode = false;
 
     private function __construct()
@@ -26,46 +26,46 @@ final class ContainerConfig implements ContainerConfigInterface
     }
 
     /**
-     * @param array $definitions Definitions to put into container.
+     * @param iterable $definitions Definitions to put into container.
      */
-    public function withDefinitions(array $definitions): self
+    public function withDefinitions(iterable $definitions): self
     {
         $new = clone $this;
         $new->definitions = $definitions;
         return $new;
     }
 
-    public function getDefinitions(): array
+    public function getDefinitions(): iterable
     {
         return $this->definitions;
     }
 
     /**
-     * @param array $providers Service providers to get definitions from.
+     * @param iterable $providers Service providers to get definitions from.
      */
-    public function withProviders(array $providers): self
+    public function withProviders(iterable $providers): self
     {
         $new = clone $this;
         $new->providers = $providers;
         return $new;
     }
 
-    public function getProviders(): array
+    public function getProviders(): iterable
     {
         return $this->providers;
     }
 
     /**
-     * @param array $tags Tagged service IDs. The structure is `['tagID' => ['service1', 'service2']]`.
+     * @param iterable $tags Tagged service IDs. The structure is `['tagID' => ['service1', 'service2']]`.
      */
-    public function withTags(array $tags): self
+    public function withTags(iterable $tags): self
     {
         $new = clone $this;
         $new->tags = $tags;
         return $new;
     }
 
-    public function getTags(): array
+    public function getTags(): iterable
     {
         return $this->tags;
     }
@@ -86,18 +86,18 @@ final class ContainerConfig implements ContainerConfigInterface
     }
 
     /**
-     * @param array $delegates Container delegates. Each delegate is a callable in format
+     * @param iterable $delegates Container delegates. Each delegate is a callable in format
      * `function (ContainerInterface $container): ContainerInterface`. The container instance returned is used
      * in case a service can not be found in primary container.
      */
-    public function withDelegates(array $delegates): self
+    public function withDelegates(iterable $delegates): self
     {
         $new = clone $this;
         $new->delegates = $delegates;
         return $new;
     }
 
-    public function getDelegates(): array
+    public function getDelegates(): iterable
     {
         return $this->delegates;
     }

--- a/src/ContainerConfigInterface.php
+++ b/src/ContainerConfigInterface.php
@@ -12,17 +12,17 @@ interface ContainerConfigInterface
     /**
      * @return array Definitions to put into container.
      */
-    public function getDefinitions(): array;
+    public function getDefinitions(): iterable;
 
     /**
-     * @return array Service providers to get definitions from.
+     * @return iterable Service providers to get definitions from.
      */
-    public function getProviders(): array;
+    public function getProviders(): iterable;
 
     /**
-     * @return array Tagged service IDs. The structure is `['tagID' => ['service1', 'service2']]`.
+     * @return iterable Tagged service IDs. The structure is `['tagID' => ['service1', 'service2']]`.
      */
-    public function getTags(): array;
+    public function getTags(): iterable;
 
     /**
      * @return bool Whether definitions should be validated immediately.
@@ -30,11 +30,11 @@ interface ContainerConfigInterface
     public function shouldValidate(): bool;
 
     /**
-     * @return array Container delegates. Each delegate is a callable in format
+     * @return iterable Container delegates. Each delegate is a callable in format
      * `function (ContainerInterface $container): ContainerInterface`. The container instance returned is used
      * in case a service can not be found in primary container.
      */
-    public function getDelegates(): array;
+    public function getDelegates(): iterable;
 
     /**
      * @return bool If the automatic addition of definition when class exists and can be resolved is disabled.

--- a/src/ContainerConfigInterface.php
+++ b/src/ContainerConfigInterface.php
@@ -10,7 +10,7 @@ namespace Yiisoft\Di;
 interface ContainerConfigInterface
 {
     /**
-     * @return array Definitions to put into container.
+     * @return iterable Definitions to put into container.
      */
     public function getDefinitions(): iterable;
 

--- a/src/ServiceProviderInterface.php
+++ b/src/ServiceProviderInterface.php
@@ -42,7 +42,7 @@ interface ServiceProviderInterface
      * @return array Definitions for the container. Each array key is the name of the service (usually it is
      * an interface name), and a corresponding value is a service definition.
      */
-    public function getDefinitions(): array;
+    public function getDefinitions(): iterable;
 
     /**
      * Returns an array of service extensions.
@@ -58,5 +58,5 @@ interface ServiceProviderInterface
      * @return array Extensions for the container services. Each array key is the name of the service to be modified
      * and a corresponding value is callable doing the job.
      */
-    public function getExtensions(): array;
+    public function getExtensions(): iterable;
 }

--- a/tests/Support/CarExtensionProvider.php
+++ b/tests/Support/CarExtensionProvider.php
@@ -9,12 +9,12 @@ use Yiisoft\Di\ServiceProviderInterface;
 
 final class CarExtensionProvider implements ServiceProviderInterface
 {
-    public function getDefinitions(): array
+    public function getDefinitions(): iterable
     {
         return [];
     }
 
-    public function getExtensions(): array
+    public function getExtensions(): iterable
     {
         return [
             Car::class => static function (ContainerInterface $container, Car $car) {

--- a/tests/Support/CarProvider.php
+++ b/tests/Support/CarProvider.php
@@ -9,7 +9,7 @@ use Yiisoft\Di\ServiceProviderInterface;
 
 final class CarProvider implements ServiceProviderInterface
 {
-    public function getDefinitions(): array
+    public function getDefinitions(): iterable
     {
         return [
             'car' => Car::class,
@@ -17,7 +17,7 @@ final class CarProvider implements ServiceProviderInterface
         ];
     }
 
-    public function getExtensions(): array
+    public function getExtensions(): iterable
     {
         return [
             Car::class => static function (ContainerInterface $container, Car $car) {

--- a/tests/Support/ContainerInterfaceExtensionProvider.php
+++ b/tests/Support/ContainerInterfaceExtensionProvider.php
@@ -9,12 +9,12 @@ use Yiisoft\Di\ServiceProviderInterface;
 
 final class ContainerInterfaceExtensionProvider implements ServiceProviderInterface
 {
-    public function getDefinitions(): array
+    public function getDefinitions(): iterable
     {
         return [];
     }
 
-    public function getExtensions(): array
+    public function getExtensions(): iterable
     {
         return [
             ContainerInterface::class => static fn (ContainerInterface $container, ContainerInterface $extended) => $container,

--- a/tests/Support/NullCarExtensionProvider.php
+++ b/tests/Support/NullCarExtensionProvider.php
@@ -9,13 +9,13 @@ use Yiisoft\Di\ServiceProviderInterface;
 
 final class NullCarExtensionProvider implements ServiceProviderInterface
 {
-    public function getDefinitions(): array
+    public function getDefinitions(): iterable
     {
         return [
         ];
     }
 
-    public function getExtensions(): array
+    public function getExtensions(): iterable
     {
         return [
             Car::class => static fn (ContainerInterface $container, Car $car) => null,

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1963,7 +1963,7 @@ final class ContainerTest extends TestCase
         $this->expectExceptionMessage(
             'Invalid definition: incorrect method "setNumber()" arguments. Expected array, got "int". Probably you should wrap them into square brackets.',
         );
-        $container = new Container($config);
+        new Container($config);
     }
 
     public function dataInvalidTags(): array

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1970,15 +1970,15 @@ final class ContainerTest extends TestCase
     {
         return [
             [
-                '/^Invalid tags configuration: tag should be string, 42 given\.$/',
+                'Invalid tags configuration: tag should be string, array given.',
                 [42 => [EngineMarkTwo::class]],
             ],
             [
-                'Invalid tags configuration: tag should be either iterable or array of service IDs, integer given.',
+                'Invalid tags configuration: tag should be either iterable or array of service IDs, int given.',
                 ['engine' => 42],
             ],
             [
-                '/^Invalid tags configuration: service should be defined as class string, (integer|int) given\.$/',
+                'Invalid tags configuration: service should be defined as class string, int given.',
                 ['engine' => [42]],
             ],
         ];
@@ -1993,7 +1993,7 @@ final class ContainerTest extends TestCase
             ->withTags($tags);
 
         $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionMessageMatches($message);
+        $this->expectExceptionMessage($message);
         new Container($config);
     }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1795,7 +1795,7 @@ final class ContainerTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage(
-            'Invalid definition: tags should be iterable object or array of strings, integer given.'
+            'Invalid definition: tags should be either iterable or array of strings, integer given.'
         );
         new Container($config);
     }
@@ -1808,7 +1808,7 @@ final class ContainerTest extends TestCase
                 [42 => [EngineMarkTwo::class]],
             ],
             [
-                'Invalid tags configuration: tag should be iterable object or array of service IDs, integer given.',
+                'Invalid tags configuration: tag should be either iterable or array of service IDs, integer given.',
                 ['engine' => 42],
             ],
             [

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1804,7 +1804,7 @@ final class ContainerTest extends TestCase
     {
         return [
             [
-                'Invalid tags configuration: tag should be string, 42 given.',
+                'Invalid tags configuration: tag should be string, integer given.',
                 [42 => [EngineMarkTwo::class]],
             ],
             [

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1107,8 +1107,8 @@ final class ContainerTest extends TestCase
 
         $this->assertIsArray($engines);
         $this->assertCount(2, $engines);
-        $this->assertSame(EngineMarkOne::class, get_class($engines[1]));
-        $this->assertSame(EngineMarkTwo::class, get_class($engines[0]));
+        $this->assertSame(EngineMarkOne::class, $engines[1]::class);
+        $this->assertSame(EngineMarkTwo::class, $engines[0]::class);
     }
 
     public function testTagsWithExternalDefinitionMerge(): void

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1996,4 +1996,25 @@ final class ContainerTest extends TestCase
         $this->expectExceptionMessage($message);
         new Container($config);
     }
+
+    public function testSupportIterableDefinitions(): void
+    {
+        $config = ContainerConfig::create()
+            ->withDefinitions(
+                (function () {
+                    yield from [
+                        EngineMarkOne::class => [
+                            'class' => EngineMarkOne::class,
+                            'setNumber()' => [42],
+                        ],
+                    ];
+                })()
+            );
+
+        $container = new Container($config);
+
+        $this->assertTrue($container->has(EngineMarkOne::class));
+        $engine = $container->get(EngineMarkOne::class);
+        $this->assertEquals(42, $engine->getNumber());
+    }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1092,6 +1092,30 @@ final class ContainerTest extends TestCase
         $this->assertSame(EngineMarkTwo::class, get_class($engines[0]));
     }
 
+    public function testTagsIterable(): void
+    {
+        $config = ContainerConfig::create()
+            ->withDefinitions([
+                EngineMarkOne::class => [
+                    'class' => EngineMarkOne::class,
+                    'tags' => ['engine'],
+                ],
+                EngineMarkTwo::class => [
+                    'class' => EngineMarkTwo::class,
+                ],
+            ])
+            ->withTags(['engine' => new ArrayIterator([EngineMarkTwo::class])])
+            ->withValidate(true);
+        $container = new Container($config);
+
+        $engines = $container->get('tag@engine');
+
+        $this->assertIsArray($engines);
+        $this->assertCount(2, $engines);
+        $this->assertSame(EngineMarkOne::class, get_class($engines[1]));
+        $this->assertSame(EngineMarkTwo::class, get_class($engines[0]));
+    }
+
     public function testTagsWithExternalDefinitionMerge(): void
     {
         $config = ContainerConfig::create()
@@ -1771,7 +1795,7 @@ final class ContainerTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessage(
-            'Invalid definition: tags should be array of strings, integer given.'
+            'Invalid definition: tags should be iterable object or array of strings, integer given.'
         );
         new Container($config);
     }
@@ -1784,7 +1808,7 @@ final class ContainerTest extends TestCase
                 [42 => [EngineMarkTwo::class]],
             ],
             [
-                'Invalid tags configuration: tag should contain array of service IDs, integer given.',
+                'Invalid tags configuration: tag should be iterable object or array of service IDs, integer given.',
                 ['engine' => 42],
             ],
             [

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -10,14 +10,18 @@ use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use RuntimeException;
 use stdClass;
+use Yiisoft\Definitions\DynamicReference;
+use Yiisoft\Definitions\Exception\CircularReferenceException;
+use Yiisoft\Definitions\Exception\InvalidConfigException;
+use Yiisoft\Definitions\Reference;
 use Yiisoft\Di\BuildingException;
 use Yiisoft\Di\CompositeContainer;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\ContainerConfig;
 use Yiisoft\Di\ExtensibleService;
 use Yiisoft\Di\NotFoundException;
-use Yiisoft\Di\StateResetter;
 use Yiisoft\Di\ServiceProviderInterface;
+use Yiisoft\Di\StateResetter;
 use Yiisoft\Di\Tests\Support\A;
 use Yiisoft\Di\Tests\Support\B;
 use Yiisoft\Di\Tests\Support\Car;
@@ -41,15 +45,11 @@ use Yiisoft\Di\Tests\Support\OptionalConcreteDependency;
 use Yiisoft\Di\Tests\Support\PropertyTestClass;
 use Yiisoft\Di\Tests\Support\SportCar;
 use Yiisoft\Di\Tests\Support\TreeItem;
-use Yiisoft\Di\Tests\Support\UnionTypeInConstructorSecondTypeInParamResolvable;
-use Yiisoft\Di\Tests\Support\UnionTypeInConstructorSecondParamNotResolvable;
-use Yiisoft\Di\Tests\Support\UnionTypeInConstructorParamNotResolvable;
 use Yiisoft\Di\Tests\Support\UnionTypeInConstructorFirstTypeInParamResolvable;
+use Yiisoft\Di\Tests\Support\UnionTypeInConstructorParamNotResolvable;
+use Yiisoft\Di\Tests\Support\UnionTypeInConstructorSecondParamNotResolvable;
+use Yiisoft\Di\Tests\Support\UnionTypeInConstructorSecondTypeInParamResolvable;
 use Yiisoft\Di\Tests\Support\VariadicConstructor;
-use Yiisoft\Definitions\DynamicReference;
-use Yiisoft\Definitions\Exception\CircularReferenceException;
-use Yiisoft\Definitions\Exception\InvalidConfigException;
-use Yiisoft\Definitions\Reference;
 use Yiisoft\Injector\Injector;
 
 /**
@@ -1397,7 +1397,7 @@ final class ContainerTest extends TestCase
             ])
             ->withProviders([
                 new class () implements ServiceProviderInterface {
-                    public function getDefinitions(): array
+                    public function getDefinitions(): iterable
                     {
                         return [
                             StateResetter::class => static function (ContainerInterface $container) {
@@ -1412,7 +1412,7 @@ final class ContainerTest extends TestCase
                         ];
                     }
 
-                    public function getExtensions(): array
+                    public function getExtensions(): iterable
                     {
                         return [];
                     }
@@ -1442,12 +1442,12 @@ final class ContainerTest extends TestCase
             ])
             ->withProviders([
                 new class () implements ServiceProviderInterface {
-                    public function getDefinitions(): array
+                    public function getDefinitions(): iterable
                     {
                         return [];
                     }
 
-                    public function getExtensions(): array
+                    public function getExtensions(): iterable
                     {
                         return [
                             StateResetter::class => static function (
@@ -1622,7 +1622,7 @@ final class ContainerTest extends TestCase
     public function testCircularReferenceExceptionWhileResolvingProviders(): void
     {
         $provider = new class () implements ServiceProviderInterface {
-            public function getDefinitions(): array
+            public function getDefinitions(): iterable
             {
                 return [
                     // E.g. wrapping container with proxy class
@@ -1630,7 +1630,7 @@ final class ContainerTest extends TestCase
                 ];
             }
 
-            public function getExtensions(): array
+            public function getExtensions(): iterable
             {
                 return [];
             }
@@ -1655,14 +1655,14 @@ final class ContainerTest extends TestCase
     public function testDifferentContainerWithProviders(): void
     {
         $provider = new class () implements ServiceProviderInterface {
-            public function getDefinitions(): array
+            public function getDefinitions(): iterable
             {
                 return [
                     ContainerInterface::class => static fn (ContainerInterface $container) => new Container(ContainerConfig::create()),
                 ];
             }
 
-            public function getExtensions(): array
+            public function getExtensions(): iterable
             {
                 return [];
             }
@@ -1870,12 +1870,12 @@ final class ContainerTest extends TestCase
         $config = ContainerConfig::create()
             ->withProviders([
                 new class () implements ServiceProviderInterface {
-                    public function getDefinitions(): array
+                    public function getDefinitions(): iterable
                     {
                         return [];
                     }
 
-                    public function getExtensions(): array
+                    public function getExtensions(): iterable
                     {
                         return [
                             23 => static fn (ContainerInterface $container, StateResetter $resetter) => $resetter,
@@ -1894,12 +1894,12 @@ final class ContainerTest extends TestCase
         $config = ContainerConfig::create()
             ->withProviders([
                 new class () implements ServiceProviderInterface {
-                    public function getDefinitions(): array
+                    public function getDefinitions(): iterable
                     {
                         return [];
                     }
 
-                    public function getExtensions(): array
+                    public function getExtensions(): iterable
                     {
                         return [
                             ColorPink::class => [],

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -6,21 +6,21 @@ namespace Yiisoft\Di\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Di\Container;
 use Yiisoft\Di\ContainerConfig;
 use Yiisoft\Di\ServiceProviderInterface;
 use Yiisoft\Di\Tests\Support\Car;
-use Yiisoft\Di\Tests\Support\CarProvider;
 use Yiisoft\Di\Tests\Support\CarExtensionProvider;
-use Yiisoft\Di\Tests\Support\ContainerInterfaceExtensionProvider;
+use Yiisoft\Di\Tests\Support\CarProvider;
 use Yiisoft\Di\Tests\Support\ColorRed;
+use Yiisoft\Di\Tests\Support\ContainerInterfaceExtensionProvider;
 use Yiisoft\Di\Tests\Support\EngineInterface;
 use Yiisoft\Di\Tests\Support\EngineMarkOne;
 use Yiisoft\Di\Tests\Support\EngineMarkTwo;
 use Yiisoft\Di\Tests\Support\MethodTestClass;
 use Yiisoft\Di\Tests\Support\NullCarExtensionProvider;
 use Yiisoft\Di\Tests\Support\SportCar;
-use Yiisoft\Definitions\Exception\InvalidConfigException;
 
 final class ServiceProviderTest extends TestCase
 {
@@ -174,12 +174,12 @@ final class ServiceProviderTest extends TestCase
             ])
             ->withProviders([
                 new class () implements ServiceProviderInterface {
-                    public function getDefinitions(): array
+                    public function getDefinitions(): iterable
                     {
                         return [];
                     }
 
-                    public function getExtensions(): array
+                    public function getExtensions(): iterable
                     {
                         return [
                             'method_test' => static fn (ContainerInterface $container, MethodTestClass $class) => $class,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | 

Added ability to use iterable parameters.
For example, now you cannot use Generator as tags values.