### PR TITLE
Fix incorrect result of `Container::has()` on check empty tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ## 1.0.3 June 17, 2022
 
-- Enh #302: Improve performance collecting tags (samdark)
+- Enh #302: Improve performance collecting tags (@samdark)
 - Enh #303: Add support for `yiisoft/definitions` version `^2.0` (@vjik)
 
 ## 1.0.2 February 14, 2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- Bug #312: Add check of tag services array on empty (@vjik)
+- Bug #312: Fix incorrect result of `Container::has()` on check empty tag (@vjik)
 
 ## 1.2.0 November 05, 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- no changes in this release.
+- Bug #312: Add check of tag services array on empty (@vjik)
 
 ## 1.2.0 November 05, 2022
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -100,7 +100,7 @@ final class Container implements ContainerInterface
     {
         if (TagHelper::isTagAlias($id)) {
             $tag = TagHelper::extractTagFromAlias($id);
-            return isset($this->tags[$tag]);
+            return !empty($this->tags[$tag]);
         }
 
         try {
@@ -390,15 +390,6 @@ final class Container implements ContainerInterface
                         sprintf(
                             'Invalid tags configuration: tag should contain array of service IDs, %s given.',
                             get_debug_type($services)
-                        )
-                    );
-                }
-                if (empty($services)) {
-                    throw new InvalidConfigException(
-                        sprintf(
-                            'Invalid tags configuration: tag should contain non-empty array of service IDs, ' .
-                            'empty tag "%s" given.',
-                            $tag
                         )
                     );
                 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -393,6 +393,15 @@ final class Container implements ContainerInterface
                         )
                     );
                 }
+                if (empty($services)) {
+                    throw new InvalidConfigException(
+                        sprintf(
+                            'Invalid tags configuration: tag should contain non-empty array of service IDs, ' .
+                            'empty tag "%s" given.',
+                            $tag
+                        )
+                    );
+                }
                 /** @var mixed $service */
                 foreach ($services as $service) {
                     if (!is_string($service)) {

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use RectorPrefix202211\Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use RuntimeException;
 use stdClass;
 use Yiisoft\Di\CompositeContainer;
@@ -1893,6 +1894,18 @@ final class ContainerTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessageMatches($message);
+        new Container($config);
+    }
+
+    public function testEmptyTag(): void
+    {
+        $config = ContainerConfig::create()
+            ->withTags(['sources' => []]);
+
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage(
+            'Invalid tags configuration: tag should contain non-empty array of service IDs, empty tag "sources" given.'
+        );
         new Container($config);
     }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -50,6 +50,7 @@ use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Reference;
 use Yiisoft\Injector\Injector;
+use Yiisoft\Test\Support\Container\SimpleContainer;
 
 /**
  * ContainerTest contains tests for \Yiisoft\Di\Container
@@ -153,6 +154,31 @@ final class ContainerTest extends TestCase
         $container = new Container($config);
 
         $this->assertSame($expected, $container->has($id));
+    }
+
+    public function dataHasTags(): array
+    {
+        return [
+            [false, 'non-exist'],
+            [false, 'sources'],
+            [true, 'colors'],
+        ];
+    }
+
+    /**
+     * @dataProvider dataHasTags
+     */
+    public function testHasTags(bool $expected, string $tag): void
+    {
+        $config = ContainerConfig::create()
+            ->withTags([
+                'sources' => [],
+                'colors' => [ColorPink::class, ColorRed::class],
+            ]);
+
+        $container = new Container($config);
+
+        $this->assertSame($expected, $container->has('tag@' . $tag));
     }
 
     public function dataUnionTypes(): array
@@ -1893,18 +1919,6 @@ final class ContainerTest extends TestCase
 
         $this->expectException(InvalidConfigException::class);
         $this->expectExceptionMessageMatches($message);
-        new Container($config);
-    }
-
-    public function testEmptyTag(): void
-    {
-        $config = ContainerConfig::create()
-            ->withTags(['sources' => []]);
-
-        $this->expectException(InvalidConfigException::class);
-        $this->expectExceptionMessage(
-            'Invalid tags configuration: tag should contain non-empty array of service IDs, empty tag "sources" given.'
-        );
         new Container($config);
     }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -50,7 +50,6 @@ use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Reference;
 use Yiisoft\Injector\Injector;
-use Yiisoft\Test\Support\Container\SimpleContainer;
 
 /**
  * ContainerTest contains tests for \Yiisoft\Di\Container


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #312 