### PR TITLE
Performance optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.4.2 under development
 
+- Enh #400: Improve container performance and make `has()` cache limit configurable (@samdark)
 - Enh #397: Explicitly import functions in "use" section (@mspirkov)
 
 ## 1.4.1 December 01, 2025

--- a/README.md
+++ b/README.md
@@ -617,6 +617,20 @@ $config = ContainerConfig::create()
 $container = new Container($config);
 ```
 
+The container caches `has()` results to speed up repeated lookups. The cache is limited to 1024 entries by default.
+If your application checks many dynamic service IDs in a long-running process, you can adjust the limit or disable the
+cache:
+
+```php
+use Yiisoft\Di\Container;
+use Yiisoft\Di\ContainerConfig;
+
+$config = ContainerConfig::create()
+    ->withHasCacheLimit(0); // Disable `has()` cache.
+
+$container = new Container($config);
+```
+
 ## Strict mode
 
 Container may work in a strict mode, that's when you should define everything in the container explicitly.

--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -26,6 +26,13 @@ final class CompositeContainer implements ContainerInterface
     private array $containers = [];
 
     /**
+     * Index of a container where a service ID was previously found.
+     *
+     * @psalm-var array<string, int>
+     */
+    private array $lookupCache = [];
+
+    /**
      * @psalm-template T
      * @psalm-param string|class-string<T> $id
      * @psalm-return ($id is class-string ? T : mixed)
@@ -71,8 +78,14 @@ final class CompositeContainer implements ContainerInterface
             return array_merge(...$tags);
         }
 
-        foreach ($this->containers as $container) {
+        if (isset($this->lookupCache[$id], $this->containers[$this->lookupCache[$id]])) {
+            /** @psalm-suppress MixedReturnStatement */
+            return $this->containers[$this->lookupCache[$id]]->get($id);
+        }
+
+        foreach ($this->containers as $index => $container) {
             if ($container->has($id)) {
+                $this->lookupCache[$id] = (int) $index;
                 /** @psalm-suppress MixedReturnStatement */
                 return $container->get($id);
             }
@@ -130,8 +143,13 @@ final class CompositeContainer implements ContainerInterface
             return false;
         }
 
-        foreach ($this->containers as $container) {
+        if (isset($this->lookupCache[$id], $this->containers[$this->lookupCache[$id]])) {
+            return true;
+        }
+
+        foreach ($this->containers as $index => $container) {
             if ($container->has($id)) {
+                $this->lookupCache[$id] = (int) $index;
                 return true;
             }
         }
@@ -155,6 +173,7 @@ final class CompositeContainer implements ContainerInterface
         foreach ($this->containers as $i => $c) {
             if ($container === $c) {
                 unset($this->containers[$i]);
+                $this->lookupCache = [];
             }
         }
     }

--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -6,6 +6,7 @@ namespace Yiisoft\Di;
 
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use RuntimeException;
 use Throwable;
 use Yiisoft\Di\Reference\TagReference;
@@ -79,8 +80,16 @@ final class CompositeContainer implements ContainerInterface
         }
 
         if (isset($this->lookupCache[$id], $this->containers[$this->lookupCache[$id]])) {
-            /** @psalm-suppress MixedReturnStatement */
-            return $this->containers[$this->lookupCache[$id]]->get($id);
+            $index = $this->lookupCache[$id];
+            $container = $this->containers[$index];
+            if ($container->has($id)) {
+                try {
+                    /** @psalm-suppress MixedReturnStatement */
+                    return $container->get($id);
+                } catch (NotFoundExceptionInterface) {
+                }
+            }
+            unset($this->lookupCache[$id]);
         }
 
         foreach ($this->containers as $index => $container) {
@@ -144,7 +153,11 @@ final class CompositeContainer implements ContainerInterface
         }
 
         if (isset($this->lookupCache[$id], $this->containers[$this->lookupCache[$id]])) {
-            return true;
+            $index = $this->lookupCache[$id];
+            if ($this->containers[$index]->has($id)) {
+                return true;
+            }
+            unset($this->lookupCache[$id]);
         }
 
         foreach ($this->containers as $index => $container) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -141,19 +141,6 @@ final class Container implements ContainerInterface
         return $this->cacheHasResult($id, false);
     }
 
-    private function cacheHasResult(string $id, bool $result): bool
-    {
-        if ($this->hasCacheLimit === 0) {
-            return $result;
-        }
-
-        if (count($this->hasCache) >= $this->hasCacheLimit) {
-            $this->hasCache = [];
-        }
-
-        return $this->hasCache[$id] = $result;
-    }
-
     /**
      * Returns an instance by either interface name or alias.
      *
@@ -231,6 +218,19 @@ final class Container implements ContainerInterface
         }
 
         return $this->instances[$id];
+    }
+
+    private function cacheHasResult(string $id, bool $result): bool
+    {
+        if ($this->hasCacheLimit === 0) {
+            return $result;
+        }
+
+        if (count($this->hasCache) >= $this->hasCacheLimit) {
+            $this->hasCache = [];
+        }
+
+        return $this->hasCache[$id] = $result;
     }
 
     private function prepareStateResetter(): StateResetter

--- a/src/Container.php
+++ b/src/Container.php
@@ -28,6 +28,7 @@ use function is_callable;
 use function is_object;
 use function is_string;
 use function sprintf;
+use function trim;
 
 /**
  * Container implements a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) container.
@@ -351,6 +352,13 @@ final class Container implements ContainerInterface
     {
         // Skip validation for common simple cases.
         if ($definition instanceof ContainerInterface || $definition instanceof Closure) {
+            return;
+        }
+
+        if (is_string($definition)) {
+            if (trim($definition) === '') {
+                throw new InvalidConfigException('Invalid definition: class name must be a non-empty string.');
+            }
             return;
         }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -408,6 +408,10 @@ final class Container implements ContainerInterface
     {
         $this->delegates = new CompositeContainer();
 
+        if ($delegates === []) {
+            return;
+        }
+
         $container = $this->get(ContainerInterface::class);
 
         foreach ($delegates as $delegate) {

--- a/src/Container.php
+++ b/src/Container.php
@@ -30,6 +30,7 @@ use function is_object;
 use function is_string;
 use function sprintf;
 use function trim;
+use function count;
 
 /**
  * Container implements a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) container.
@@ -139,15 +140,6 @@ final class Container implements ContainerInterface
         return $this->cacheHasResult($id, false);
     }
 
-    private function cacheHasResult(string $id, bool $result): bool
-    {
-        if (count($this->hasCache) >= self::HAS_CACHE_LIMIT) {
-            $this->hasCache = [];
-        }
-
-        return $this->hasCache[$id] = $result;
-    }
-
     /**
      * Returns an instance by either interface name or alias.
      *
@@ -225,6 +217,15 @@ final class Container implements ContainerInterface
         }
 
         return $this->instances[$id];
+    }
+
+    private function cacheHasResult(string $id, bool $result): bool
+    {
+        if (count($this->hasCache) >= self::HAS_CACHE_LIMIT) {
+            $this->hasCache = [];
+        }
+
+        return $this->hasCache[$id] = $result;
     }
 
     private function prepareStateResetter(): StateResetter

--- a/src/Container.php
+++ b/src/Container.php
@@ -8,6 +8,7 @@ use Closure;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use RuntimeException;
 use Throwable;
 use Yiisoft\Definitions\ArrayDefinition;
 use Yiisoft\Definitions\DefinitionStorage;
@@ -561,14 +562,15 @@ final class Container implements ContainerInterface
             return $this->getTaggedServices($id);
         }
 
-        // Check if the definition exists.
-        if (!$this->definitions->has($id)) {
+        try {
+            $definition = $this->definitions->get($id);
+        } catch (RuntimeException) {
             throw new NotFoundException($id, $this->definitions->getBuildStack());
         }
 
         $this->building[$id] = 1;
         try {
-            $normalizedDefinition = DefinitionNormalizer::normalize($this->definitions->get($id), $id);
+            $normalizedDefinition = DefinitionNormalizer::normalize($definition, $id);
             $object = $normalizedDefinition->resolve($this->get(ContainerInterface::class));
         } finally {
             unset($this->building[$id]);

--- a/src/Container.php
+++ b/src/Container.php
@@ -39,6 +39,7 @@ final class Container implements ContainerInterface
     private const META_TAGS = 'tags';
     private const META_RESET = 'reset';
     private const ALLOWED_META = [self::META_TAGS, self::META_RESET];
+    private const HAS_CACHE_LIMIT = 1024;
 
     /**
      * @var DefinitionStorage Storage of object definitions.
@@ -132,10 +133,19 @@ final class Container implements ContainerInterface
 
         if (TagReference::isTagAlias($id)) {
             $tag = TagReference::extractTagFromAlias($id);
-            return $this->hasCache[$id] = isset($this->tags[$tag]);
+            return $this->cacheHasResult($id, isset($this->tags[$tag]));
         }
 
-        return $this->hasCache[$id] = false;
+        return $this->cacheHasResult($id, false);
+    }
+
+    private function cacheHasResult(string $id, bool $result): bool
+    {
+        if (count($this->hasCache) >= self::HAS_CACHE_LIMIT) {
+            $this->hasCache = [];
+        }
+
+        return $this->hasCache[$id] = $result;
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -22,6 +22,7 @@ use Yiisoft\Di\Reference\TagReference;
 
 use function array_key_exists;
 use function array_keys;
+use function count;
 use function implode;
 use function in_array;
 use function is_array;
@@ -30,7 +31,6 @@ use function is_object;
 use function is_string;
 use function sprintf;
 use function trim;
-use function count;
 
 /**
  * Container implements a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) container.
@@ -40,7 +40,6 @@ final class Container implements ContainerInterface
     private const META_TAGS = 'tags';
     private const META_RESET = 'reset';
     private const ALLOWED_META = [self::META_TAGS, self::META_RESET];
-    private const HAS_CACHE_LIMIT = 1024;
 
     /**
      * @var DefinitionStorage Storage of object definitions.
@@ -57,6 +56,7 @@ final class Container implements ContainerInterface
      * @var bool $validate If definitions should be validated.
      */
     private readonly bool $validate;
+    private readonly int $hasCacheLimit;
 
     /**
      * @var array Cached instances.
@@ -94,6 +94,7 @@ final class Container implements ContainerInterface
         $config ??= ContainerConfig::create();
 
         $this->validate = $config->shouldValidate();
+        $this->hasCacheLimit = $config->getHasCacheLimit();
         $this->setTags($config->getTags());
 
         $definitions = $this->prepareDefinitions(
@@ -126,10 +127,10 @@ final class Container implements ContainerInterface
 
         try {
             if ($this->definitions->has($id)) {
-                return $this->hasCache[$id] = true;
+                return $this->cacheHasResult($id, true);
             }
         } catch (CircularReferenceException) {
-            return $this->hasCache[$id] = true;
+            return $this->cacheHasResult($id, true);
         }
 
         if (TagReference::isTagAlias($id)) {
@@ -138,6 +139,19 @@ final class Container implements ContainerInterface
         }
 
         return $this->cacheHasResult($id, false);
+    }
+
+    private function cacheHasResult(string $id, bool $result): bool
+    {
+        if ($this->hasCacheLimit === 0) {
+            return $result;
+        }
+
+        if (count($this->hasCache) >= $this->hasCacheLimit) {
+            $this->hasCache = [];
+        }
+
+        return $this->hasCache[$id] = $result;
     }
 
     /**
@@ -217,15 +231,6 @@ final class Container implements ContainerInterface
         }
 
         return $this->instances[$id];
-    }
-
-    private function cacheHasResult(string $id, bool $result): bool
-    {
-        if (count($this->hasCache) >= self::HAS_CACHE_LIMIT) {
-            $this->hasCache = [];
-        }
-
-        return $this->hasCache[$id] = $result;
     }
 
     private function prepareStateResetter(): StateResetter

--- a/src/Container.php
+++ b/src/Container.php
@@ -91,16 +91,18 @@ final class Container implements ContainerInterface
     {
         $config ??= ContainerConfig::create();
 
-        $this->definitions = new DefinitionStorage(
+        $this->validate = $config->shouldValidate();
+        $this->setTags($config->getTags());
+
+        $definitions = $this->prepareDefinitions(
+            $config->getDefinitions(),
             [
                 ContainerInterface::class => $this,
                 StateResetter::class => StateResetter::class,
             ],
-            $config->useStrictMode(),
         );
-        $this->validate = $config->shouldValidate();
-        $this->setTags($config->getTags());
-        $this->addDefinitions($config->getDefinitions());
+        $this->definitions = new DefinitionStorage($definitions, $config->useStrictMode());
+
         $this->addProviders($config->getProviders());
         $this->setDelegates($config->getDelegates());
     }
@@ -344,6 +346,54 @@ final class Container implements ContainerInterface
                 $this->useResettersFromMeta = false;
             }
         }
+    }
+
+    private function prepareDefinitions(array $config, array $definitions): array
+    {
+        foreach ($config as $id => $definition) {
+            if ($this->validate && !is_string($id)) {
+                throw new InvalidConfigException(
+                    sprintf(
+                        'Key must be a string. %s given.',
+                        get_debug_type($id),
+                    ),
+                );
+            }
+            /** @var string $id */
+
+            if (is_array($definition)) {
+                [$definition, $meta] = DefinitionParser::parse($definition);
+            } else {
+                $meta = [];
+            }
+
+            if ($this->validate) {
+                $this->validateDefinition($definition, $id);
+                // Only validate meta if it's not empty.
+                if ($meta !== []) {
+                    $this->validateMeta($meta);
+                }
+            }
+            /**
+             * @psalm-var array{reset?:Closure,tags?:string[]} $meta
+             */
+
+            // Process meta only if it has tags or reset callback.
+            if (isset($meta[self::META_TAGS])) {
+                $this->setDefinitionTags($id, $meta[self::META_TAGS]);
+            }
+            if (isset($meta[self::META_RESET])) {
+                $this->setDefinitionResetter($id, $meta[self::META_RESET]);
+            }
+
+            if ($id === StateResetter::class) {
+                $this->useResettersFromMeta = false;
+            }
+
+            $definitions[$id] = $definition;
+        }
+
+        return $definitions;
     }
 
     /**

--- a/src/Container.php
+++ b/src/Container.php
@@ -259,7 +259,12 @@ final class Container implements ContainerInterface
      */
     private function addDefinition(string $id, mixed $definition): void
     {
-        [$definition, $meta] = DefinitionParser::parse($definition);
+        if (is_array($definition)) {
+            [$definition, $meta] = DefinitionParser::parse($definition);
+        } else {
+            $meta = [];
+        }
+
         if ($this->validate) {
             $this->validateDefinition($definition, $id);
             // Only validate meta if it's not empty.

--- a/src/Container.php
+++ b/src/Container.php
@@ -301,8 +301,10 @@ final class Container implements ContainerInterface
      */
     private function addDefinitions(array $config): void
     {
+        $this->hasCache = [];
+
         foreach ($config as $id => $definition) {
-            if ($this->validate && !is_string($id)) {
+            if (!is_string($id)) {
                 throw new InvalidConfigException(
                     sprintf(
                         'Key must be a string. %s given.',
@@ -338,7 +340,6 @@ final class Container implements ContainerInterface
             }
 
             unset($this->instances[$id]);
-            $this->hasCache = [];
 
             $this->definitions->set($id, $definition);
 
@@ -401,6 +402,14 @@ final class Container implements ContainerInterface
     private function prepareDefinitionsWithoutValidation(array $config, array $definitions): array
     {
         foreach ($config as $id => $definition) {
+            if (!is_string($id)) {
+                throw new InvalidConfigException(
+                    sprintf(
+                        'Key must be a string. %s given.',
+                        get_debug_type($id),
+                    ),
+                );
+            }
             /** @var string $id */
             if (is_array($definition)) {
                 [$definition, $meta] = DefinitionParser::parse($definition);

--- a/src/Container.php
+++ b/src/Container.php
@@ -310,7 +310,39 @@ final class Container implements ContainerInterface
             }
             /** @var string $id */
 
-            $this->addDefinition($id, $definition);
+            if (is_array($definition)) {
+                [$definition, $meta] = DefinitionParser::parse($definition);
+            } else {
+                $meta = [];
+            }
+
+            if ($this->validate) {
+                $this->validateDefinition($definition, $id);
+                // Only validate meta if it's not empty.
+                if ($meta !== []) {
+                    $this->validateMeta($meta);
+                }
+            }
+            /**
+             * @psalm-var array{reset?:Closure,tags?:string[]} $meta
+             */
+
+            // Process meta only if it has tags or reset callback.
+            if (isset($meta[self::META_TAGS])) {
+                $this->setDefinitionTags($id, $meta[self::META_TAGS]);
+            }
+            if (isset($meta[self::META_RESET])) {
+                $this->setDefinitionResetter($id, $meta[self::META_RESET]);
+            }
+
+            unset($this->instances[$id]);
+            $this->hasCache = [];
+
+            $this->definitions->set($id, $definition);
+
+            if ($id === StateResetter::class) {
+                $this->useResettersFromMeta = false;
+            }
         }
     }
 

--- a/src/Container.php
+++ b/src/Container.php
@@ -63,6 +63,11 @@ final class Container implements ContainerInterface
     private CompositeContainer $delegates;
 
     /**
+     * @psalm-var array<string, bool>
+     */
+    private array $hasCache = [];
+
+    /**
      * @var array Tagged service IDs. The structure is `['tagID' => ['service1', 'service2']]`.
      * @psalm-var array<string, list<string>>
      */
@@ -109,20 +114,24 @@ final class Container implements ContainerInterface
      */
     public function has(string $id): bool
     {
+        if (array_key_exists($id, $this->hasCache)) {
+            return $this->hasCache[$id];
+        }
+
         try {
             if ($this->definitions->has($id)) {
-                return true;
+                return $this->hasCache[$id] = true;
             }
         } catch (CircularReferenceException) {
-            return true;
+            return $this->hasCache[$id] = true;
         }
 
         if (TagReference::isTagAlias($id)) {
             $tag = TagReference::extractTagFromAlias($id);
-            return isset($this->tags[$tag]);
+            return $this->hasCache[$id] = isset($this->tags[$tag]);
         }
 
-        return false;
+        return $this->hasCache[$id] = false;
     }
 
     /**
@@ -269,6 +278,7 @@ final class Container implements ContainerInterface
         }
 
         unset($this->instances[$id]);
+        $this->hasCache = [];
 
         $this->addDefinitionToStorage($id, $definition);
     }

--- a/src/Container.php
+++ b/src/Container.php
@@ -350,8 +350,12 @@ final class Container implements ContainerInterface
 
     private function prepareDefinitions(array $config, array $definitions): array
     {
+        if (!$this->validate) {
+            return $this->prepareDefinitionsWithoutValidation($config, $definitions);
+        }
+
         foreach ($config as $id => $definition) {
-            if ($this->validate && !is_string($id)) {
+            if (!is_string($id)) {
                 throw new InvalidConfigException(
                     sprintf(
                         'Key must be a string. %s given.',
@@ -367,12 +371,10 @@ final class Container implements ContainerInterface
                 $meta = [];
             }
 
-            if ($this->validate) {
-                $this->validateDefinition($definition, $id);
-                // Only validate meta if it's not empty.
-                if ($meta !== []) {
-                    $this->validateMeta($meta);
-                }
+            $this->validateDefinition($definition, $id);
+            // Only validate meta if it's not empty.
+            if ($meta !== []) {
+                $this->validateMeta($meta);
             }
             /**
              * @psalm-var array{reset?:Closure,tags?:string[]} $meta
@@ -384,6 +386,36 @@ final class Container implements ContainerInterface
             }
             if (isset($meta[self::META_RESET])) {
                 $this->setDefinitionResetter($id, $meta[self::META_RESET]);
+            }
+
+            if ($id === StateResetter::class) {
+                $this->useResettersFromMeta = false;
+            }
+
+            $definitions[$id] = $definition;
+        }
+
+        return $definitions;
+    }
+
+    private function prepareDefinitionsWithoutValidation(array $config, array $definitions): array
+    {
+        foreach ($config as $id => $definition) {
+            /** @var string $id */
+            if (is_array($definition)) {
+                [$definition, $meta] = DefinitionParser::parse($definition);
+
+                /**
+                 * @psalm-var array{reset?:Closure,tags?:string[]} $meta
+                 */
+
+                // Process meta only if it has tags or reset callback.
+                if (isset($meta[self::META_TAGS])) {
+                    $this->setDefinitionTags($id, $meta[self::META_TAGS]);
+                }
+                if (isset($meta[self::META_RESET])) {
+                    $this->setDefinitionResetter($id, $meta[self::META_RESET]);
+                }
             }
 
             if ($id === StateResetter::class) {

--- a/src/ContainerConfig.php
+++ b/src/ContainerConfig.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Yiisoft\Di;
 
+use InvalidArgumentException;
+
 /**
  * Container configuration.
  */
 final class ContainerConfig implements ContainerConfigInterface
 {
+    public const DEFAULT_HAS_CACHE_LIMIT = 1024;
+
     private array $definitions = [];
     private array $providers = [];
     private array $tags = [];
     private bool $validate = true;
+    private int $hasCacheLimit = self::DEFAULT_HAS_CACHE_LIMIT;
     private array $delegates = [];
     private bool $useStrictMode = false;
 
@@ -81,6 +86,25 @@ final class ContainerConfig implements ContainerConfigInterface
     public function shouldValidate(): bool
     {
         return $this->validate;
+    }
+
+    /**
+     * @param int $limit Maximum number of cached `has()` results. `0` disables the cache.
+     */
+    public function withHasCacheLimit(int $limit): self
+    {
+        if ($limit < 0) {
+            throw new InvalidArgumentException('Has cache limit must be greater than or equal to 0.');
+        }
+
+        $new = clone $this;
+        $new->hasCacheLimit = $limit;
+        return $new;
+    }
+
+    public function getHasCacheLimit(): int
+    {
+        return $this->hasCacheLimit;
     }
 
     /**

--- a/src/ContainerConfigInterface.php
+++ b/src/ContainerConfigInterface.php
@@ -30,6 +30,11 @@ interface ContainerConfigInterface
     public function shouldValidate(): bool;
 
     /**
+     * @return int Maximum number of cached `has()` results. `0` disables the cache.
+     */
+    public function getHasCacheLimit(): int;
+
+    /**
      * @return array Container delegates. Each delegate is a callable in format
      * `function (ContainerInterface $container): ContainerInterface`. The container instance returned is used
      * in case a service can't be found in primary container.

--- a/tests/Benchmark/ContainerBench.php
+++ b/tests/Benchmark/ContainerBench.php
@@ -148,6 +148,25 @@ class ContainerBench
     }
 
     /**
+     * @Groups({"construct", "no-validation"})
+     *
+     * @throws InvalidConfigException
+     * @throws NotInstantiableException
+     */
+    public function benchConstructWithoutValidation(): void
+    {
+        $definitions = [];
+        for ($i = 0; $i < self::SERVICE_COUNT; $i++) {
+            $definitions["service$i"] = PropertyTestClass::class;
+        }
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions($definitions),
+        );
+    }
+
+    /**
      * @Groups({"lookup"})
      * @ParamProviders({"provideDefinitions"})
      */
@@ -172,6 +191,31 @@ class ContainerBench
     }
 
     /**
+     * @Groups({"lookup", "no-validation"})
+     * @ParamProviders({"provideDefinitions"})
+     */
+    public function benchSequentialLookupsWithoutValidation($params): void
+    {
+        $definitions = [];
+        for ($i = 0; $i < self::SERVICE_COUNT; $i++) {
+            $definitions["service$i"] = $params['serviceClass'];
+        }
+        if (isset($params['otherDefinitions'])) {
+            $definitions = array_merge($definitions, $params['otherDefinitions']);
+        }
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions($definitions),
+        );
+        for ($i = 0; $i < self::SERVICE_COUNT / 2; $i++) {
+            // Do array lookup.
+            $index = $this->indexes[$i];
+            $container->get("service$index");
+        }
+    }
+
+    /**
      * @Groups({"lookup"})
      * @ParamProviders({"provideDefinitions"})
      */
@@ -186,6 +230,31 @@ class ContainerBench
         }
         $container = new Container(
             ContainerConfig::create()
+                ->withDefinitions($definitions),
+        );
+        for ($i = 0; $i < self::SERVICE_COUNT / 2; $i++) {
+            // Do array lookup.
+            $index = $this->randomIndexes[$i];
+            $container->get("service$index");
+        }
+    }
+
+    /**
+     * @Groups({"lookup", "no-validation"})
+     * @ParamProviders({"provideDefinitions"})
+     */
+    public function benchRandomLookupsWithoutValidation($params): void
+    {
+        $definitions = [];
+        for ($i = 0; $i < self::SERVICE_COUNT; $i++) {
+            $definitions["service$i"] = $params['serviceClass'];
+        }
+        if (isset($params['otherDefinitions'])) {
+            $definitions = array_merge($definitions, $params['otherDefinitions']);
+        }
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
                 ->withDefinitions($definitions),
         );
         for ($i = 0; $i < self::SERVICE_COUNT / 2; $i++) {

--- a/tests/Benchmark/TypicalUsageBench.php
+++ b/tests/Benchmark/TypicalUsageBench.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Di\Tests\Benchmark;
+
+use PhpBench\Benchmark\Metadata\Annotations\BeforeMethods;
+use PhpBench\Benchmark\Metadata\Annotations\Groups;
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use Psr\Container\ContainerInterface;
+use Yiisoft\Definitions\Reference;
+use Yiisoft\Di\Container;
+use Yiisoft\Di\ContainerConfig;
+use Yiisoft\Di\Reference\TagReference;
+use Yiisoft\Di\Tests\Support\Car;
+use Yiisoft\Di\Tests\Support\CarFactory;
+use Yiisoft\Di\Tests\Support\ColorInterface;
+use Yiisoft\Di\Tests\Support\ColorRed;
+use Yiisoft\Di\Tests\Support\EngineInterface;
+use Yiisoft\Di\Tests\Support\EngineMarkOne;
+use Yiisoft\Di\Tests\Support\EngineMarkTwo;
+
+/**
+ * @Iterations(5)
+ * @Revs(1000)
+ * @BeforeMethods({"before"})
+ */
+class TypicalUsageBench
+{
+    private Container $cachedServiceContainer;
+
+    public function before(): void
+    {
+        $this->cachedServiceContainer = new Container(
+            ContainerConfig::create()
+                ->withDefinitions([
+                    EngineInterface::class => EngineMarkOne::class,
+                    Car::class => Car::class,
+                ]),
+        );
+        $this->cachedServiceContainer->get(Car::class);
+    }
+
+    /**
+     * Measures the hot path after the shared service was already built.
+     *
+     * @Groups({"lookup", "typical"})
+     */
+    public function benchCachedSharedService(): void
+    {
+        $this->cachedServiceContainer->get(Car::class);
+    }
+
+    /**
+     * Measures first resolution of an autowired object graph by class name.
+     *
+     * @Groups({"lookup", "autowire", "typical"})
+     * @Revs(100)
+     */
+    public function benchAutowireObjectGraph(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withDefinitions([
+                    EngineInterface::class => EngineMarkOne::class,
+                ]),
+        );
+
+        $container->get(Car::class);
+    }
+
+    /**
+     * Measures explicit array definitions with constructor, setter, and reference resolution.
+     *
+     * @Groups({"lookup", "definition", "typical"})
+     * @Revs(100)
+     */
+    public function benchArrayDefinitionObjectGraph(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withDefinitions([
+                    EngineInterface::class => EngineMarkOne::class,
+                    ColorInterface::class => ColorRed::class,
+                    'car' => [
+                        'class' => Car::class,
+                        '__construct()' => [Reference::to(EngineInterface::class)],
+                        'setColor()' => [Reference::to(ColorInterface::class)],
+                    ],
+                ]),
+        );
+
+        $container->get('car');
+    }
+
+    /**
+     * Measures first resolution of a callable factory definition.
+     *
+     * @Groups({"lookup", "factory", "typical"})
+     * @Revs(100)
+     */
+    public function benchFactoryDefinition(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withDefinitions([
+                    ColorInterface::class => ColorRed::class,
+                    'car' => [CarFactory::class, 'createWithColor'],
+                ]),
+        );
+
+        $container->get('car');
+    }
+
+    /**
+     * Measures collecting all services registered under a tag.
+     *
+     * @Groups({"lookup", "tag", "typical"})
+     * @Revs(100)
+     */
+    public function benchTaggedServices(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withDefinitions([
+                    EngineMarkOne::class => [
+                        'class' => EngineMarkOne::class,
+                        'tags' => ['engine'],
+                    ],
+                    EngineMarkTwo::class => [
+                        'class' => EngineMarkTwo::class,
+                        'tags' => ['engine'],
+                    ],
+                    'engine-reference' => [
+                        'definition' => Reference::to(EngineMarkOne::class),
+                        'tags' => ['engine'],
+                    ],
+                ]),
+        );
+
+        $container->get(TagReference::id('engine'));
+    }
+
+    /**
+     * Measures fallback through delegates configured on the container.
+     *
+     * @Groups({"lookup", "delegate", "typical"})
+     * @Revs(100)
+     */
+    public function benchDelegateFallback(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withDelegates([
+                    static fn(ContainerInterface $container): ContainerInterface => new Container(
+                        ContainerConfig::create()
+                            ->withDefinitions([
+                                EngineInterface::class => EngineMarkOne::class,
+                            ]),
+                    ),
+                ]),
+        );
+
+        $container->get(EngineInterface::class);
+    }
+}

--- a/tests/Benchmark/TypicalUsageBench.php
+++ b/tests/Benchmark/TypicalUsageBench.php
@@ -71,6 +71,25 @@ class TypicalUsageBench
     }
 
     /**
+     * Measures first resolution of an autowired object graph by class name without eager definition validation.
+     *
+     * @Groups({"lookup", "autowire", "typical", "no-validation"})
+     * @Revs(100)
+     */
+    public function benchAutowireObjectGraphWithoutValidation(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions([
+                    EngineInterface::class => EngineMarkOne::class,
+                ]),
+        );
+
+        $container->get(Car::class);
+    }
+
+    /**
      * Measures explicit array definitions with constructor, setter, and reference resolution.
      *
      * @Groups({"lookup", "definition", "typical"})
@@ -95,6 +114,31 @@ class TypicalUsageBench
     }
 
     /**
+     * Measures explicit array definitions with constructor, setter, and reference resolution without eager validation.
+     *
+     * @Groups({"lookup", "definition", "typical", "no-validation"})
+     * @Revs(100)
+     */
+    public function benchArrayDefinitionObjectGraphWithoutValidation(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions([
+                    EngineInterface::class => EngineMarkOne::class,
+                    ColorInterface::class => ColorRed::class,
+                    'car' => [
+                        'class' => Car::class,
+                        '__construct()' => [Reference::to(EngineInterface::class)],
+                        'setColor()' => [Reference::to(ColorInterface::class)],
+                    ],
+                ]),
+        );
+
+        $container->get('car');
+    }
+
+    /**
      * Measures first resolution of a callable factory definition.
      *
      * @Groups({"lookup", "factory", "typical"})
@@ -104,6 +148,26 @@ class TypicalUsageBench
     {
         $container = new Container(
             ContainerConfig::create()
+                ->withDefinitions([
+                    ColorInterface::class => ColorRed::class,
+                    'car' => [CarFactory::class, 'createWithColor'],
+                ]),
+        );
+
+        $container->get('car');
+    }
+
+    /**
+     * Measures first resolution of a callable factory definition without eager validation.
+     *
+     * @Groups({"lookup", "factory", "typical", "no-validation"})
+     * @Revs(100)
+     */
+    public function benchFactoryDefinitionWithoutValidation(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
                 ->withDefinitions([
                     ColorInterface::class => ColorRed::class,
                     'car' => [CarFactory::class, 'createWithColor'],
@@ -143,6 +207,36 @@ class TypicalUsageBench
     }
 
     /**
+     * Measures collecting all services registered under a tag without eager validation.
+     *
+     * @Groups({"lookup", "tag", "typical", "no-validation"})
+     * @Revs(100)
+     */
+    public function benchTaggedServicesWithoutValidation(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions([
+                    EngineMarkOne::class => [
+                        'class' => EngineMarkOne::class,
+                        'tags' => ['engine'],
+                    ],
+                    EngineMarkTwo::class => [
+                        'class' => EngineMarkTwo::class,
+                        'tags' => ['engine'],
+                    ],
+                    'engine-reference' => [
+                        'definition' => Reference::to(EngineMarkOne::class),
+                        'tags' => ['engine'],
+                    ],
+                ]),
+        );
+
+        $container->get(TagReference::id('engine'));
+    }
+
+    /**
      * Measures fallback through delegates configured on the container.
      *
      * @Groups({"lookup", "delegate", "typical"})
@@ -155,6 +249,31 @@ class TypicalUsageBench
                 ->withDelegates([
                     static fn(ContainerInterface $container): ContainerInterface => new Container(
                         ContainerConfig::create()
+                            ->withDefinitions([
+                                EngineInterface::class => EngineMarkOne::class,
+                            ]),
+                    ),
+                ]),
+        );
+
+        $container->get(EngineInterface::class);
+    }
+
+    /**
+     * Measures fallback through delegates configured on the container without eager validation.
+     *
+     * @Groups({"lookup", "delegate", "typical", "no-validation"})
+     * @Revs(100)
+     */
+    public function benchDelegateFallbackWithoutValidation(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDelegates([
+                    static fn(ContainerInterface $container): ContainerInterface => new Container(
+                        ContainerConfig::create()
+                            ->withValidate(false)
                             ->withDefinitions([
                                 EngineInterface::class => EngineMarkOne::class,
                             ]),

--- a/tests/Unit/CompositeContainerTest.php
+++ b/tests/Unit/CompositeContainerTest.php
@@ -149,8 +149,7 @@ final class MutableContainer implements ContainerInterface
 {
     public function __construct(
         public array $definitions,
-    ) {
-    }
+    ) {}
 
     public function get($id)
     {

--- a/tests/Unit/CompositeContainerTest.php
+++ b/tests/Unit/CompositeContainerTest.php
@@ -7,6 +7,7 @@ namespace Yiisoft\Di\Tests\Unit;
 use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Yiisoft\Di\CompositeContainer;
 use Yiisoft\Di\CompositeNotFoundException;
 use Yiisoft\Di\Container;
@@ -14,8 +15,10 @@ use Yiisoft\Di\ContainerConfig;
 use Yiisoft\Di\Tests\Support\EngineMarkOne;
 use Yiisoft\Di\Tests\Support\EngineMarkTwo;
 use Yiisoft\Di\Tests\Support\NonPsrContainer;
+use Yiisoft\Test\Support\Container\Exception\NotFoundException;
 use Yiisoft\Test\Support\Container\SimpleContainer;
 
+use function array_key_exists;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertSame;
 
@@ -109,5 +112,57 @@ final class CompositeContainerTest extends TestCase
         $container->attach(new SimpleContainer());
 
         assertFalse($container->has('tag@engine'));
+    }
+
+    public function testHasRechecksCachedContainer(): void
+    {
+        $container = new CompositeContainer();
+        $delegate = new MutableContainer([
+            'engine' => new EngineMarkOne(),
+        ]);
+
+        $container->attach($delegate);
+
+        $this->assertTrue($container->has('engine'));
+        unset($delegate->definitions['engine']);
+
+        assertFalse($container->has('engine'));
+    }
+
+    public function testGetFallsBackWhenCachedContainerNoLongerHasDefinition(): void
+    {
+        $container = new CompositeContainer();
+        $firstDelegate = new MutableContainer(['engine' => new EngineMarkOne()]);
+        $secondDelegate = new MutableContainer(['engine' => new EngineMarkTwo()]);
+
+        $container->attach($firstDelegate);
+        $container->attach($secondDelegate);
+
+        $this->assertInstanceOf(EngineMarkOne::class, $container->get('engine'));
+        unset($firstDelegate->definitions['engine']);
+
+        $this->assertInstanceOf(EngineMarkTwo::class, $container->get('engine'));
+    }
+}
+
+final class MutableContainer implements ContainerInterface
+{
+    public function __construct(
+        public array $definitions,
+    ) {
+    }
+
+    public function get($id)
+    {
+        if (!$this->has($id)) {
+            throw new NotFoundException($id);
+        }
+
+        return $this->definitions[$id];
+    }
+
+    public function has($id): bool
+    {
+        return array_key_exists($id, $this->definitions);
     }
 }

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -83,6 +83,19 @@ final class ContainerTest extends TestCase
         $container->get('scalar');
     }
 
+    public function testEmptyStringDefinition(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Invalid definition: class name must be a non-empty string.');
+
+        new Container(
+            ContainerConfig::create()
+                ->withDefinitions([
+                    'empty' => '',
+                ]),
+        );
+    }
+
     public function testIntegerKeys(): void
     {
         $this->expectException(InvalidConfigException::class);

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -54,6 +54,7 @@ use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Reference;
 use Yiisoft\Injector\Injector;
 use Yiisoft\Test\Support\Container\SimpleContainer;
+use InvalidArgumentException;
 
 use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertSame;
@@ -344,7 +345,7 @@ final class ContainerTest extends TestCase
 
     public function testHasCacheLimitCanNotBeNegative(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Has cache limit must be greater than or equal to 0.');
 
         ContainerConfig::create()

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -287,6 +287,19 @@ final class ContainerTest extends TestCase
         $this->assertSame($expected, $container->has($id));
     }
 
+    public function testHasCacheIsBounded(): void
+    {
+        $container = new Container();
+
+        for ($i = 0; $i < 1_100; $i++) {
+            $container->has('missing-service-' . $i);
+        }
+
+        $cacheSize = (fn(): int => count($this->hasCache))->call($container);
+
+        $this->assertLessThanOrEqual(1024, $cacheSize);
+    }
+
     public static function dataUnionTypes(): array
     {
         return [

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -110,6 +110,52 @@ final class ContainerTest extends TestCase
         $container->get(Car::class);
     }
 
+    public function testIntegerKeysWithoutValidation(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Key must be a string. int given.');
+
+        new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions([
+                    [
+                        'class' => EngineMarkOne::class,
+                        'tags' => ['engine'],
+                    ],
+                ]),
+        );
+    }
+
+    public function testIntegerKeysInProviderWithoutValidation(): void
+    {
+        $this->expectException(InvalidConfigException::class);
+        $this->expectExceptionMessage('Key must be a string. int given.');
+
+        $provider = new class implements ServiceProviderInterface {
+            public function getDefinitions(): array
+            {
+                return [
+                    [
+                        'class' => EngineMarkOne::class,
+                        'tags' => ['engine'],
+                    ],
+                ];
+            }
+
+            public function getExtensions(): array
+            {
+                return [];
+            }
+        };
+
+        new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withProviders([$provider]),
+        );
+    }
+
     public function testNullableClassDependency(): void
     {
         $container = new Container();

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -290,15 +290,65 @@ final class ContainerTest extends TestCase
 
     public function testHasCacheIsBounded(): void
     {
-        $container = new Container();
+        $definitions = [];
+        for ($i = 0; $i < 1_100; $i++) {
+            $definitions['existing-service-' . $i] = EngineMarkOne::class;
+        }
+
+        $container = new Container(
+            ContainerConfig::create()
+                ->withDefinitions($definitions),
+        );
+
+        $this->assertSame(1024, ContainerConfig::create()->getHasCacheLimit());
 
         for ($i = 0; $i < 1_100; $i++) {
             $container->has('missing-service-' . $i);
+            $container->has('existing-service-' . $i);
         }
 
         $cacheSize = (fn(): int => count($this->hasCache))->call($container);
 
         $this->assertLessThanOrEqual(1024, $cacheSize);
+    }
+
+    public function testHasCacheLimitIsConfigurable(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withHasCacheLimit(2),
+        );
+
+        $container->has('missing-service-1');
+        $container->has('missing-service-2');
+        $container->has('missing-service-3');
+
+        $cacheSize = (fn(): int => count($this->hasCache))->call($container);
+
+        $this->assertSame(1, $cacheSize);
+    }
+
+    public function testHasCacheCanBeDisabled(): void
+    {
+        $config = ContainerConfig::create()
+            ->withHasCacheLimit(0);
+        $container = new Container($config);
+
+        $this->assertSame(0, $config->getHasCacheLimit());
+        $this->assertFalse($container->has('missing-service'));
+
+        $cacheSize = (fn(): int => count($this->hasCache))->call($container);
+
+        $this->assertSame(0, $cacheSize);
+    }
+
+    public function testHasCacheLimitCanNotBeNegative(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Has cache limit must be greater than or equal to 0.');
+
+        ContainerConfig::create()
+            ->withHasCacheLimit(-1);
     }
 
     public static function dataUnionTypes(): array

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -57,6 +57,7 @@ use Yiisoft\Test\Support\Container\SimpleContainer;
 
 use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertSame;
+use function count;
 
 /**
  * ContainerTest contains tests for \Yiisoft\Di\Container

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -156,6 +156,67 @@ final class ContainerTest extends TestCase
         );
     }
 
+    public function testMetadataWithoutValidation(): void
+    {
+        $container = new Container(
+            ContainerConfig::create()
+                ->withValidate(false)
+                ->withDefinitions([
+                    EngineMarkOne::class => [
+                        'class' => EngineMarkOne::class,
+                        'tags' => ['engine'],
+                        'reset' => function (): void {
+                            $this->number = 7;
+                        },
+                    ],
+                    StateResetter::class => StateResetter::class,
+                ]),
+        );
+
+        $engines = $container->get('tag@engine');
+
+        $this->assertIsArray($engines);
+        $this->assertSame(EngineMarkOne::class, $engines[0]::class);
+    }
+
+    public function testMetadataInProviderDefinitions(): void
+    {
+        $provider = new class implements ServiceProviderInterface {
+            public function getDefinitions(): array
+            {
+                return [
+                    EngineMarkOne::class => [
+                        'class' => EngineMarkOne::class,
+                        'tags' => ['engine'],
+                        'reset' => function (): void {
+                            $this->number = 7;
+                        },
+                    ],
+                ];
+            }
+
+            public function getExtensions(): array
+            {
+                return [];
+            }
+        };
+
+        $container = new Container(
+            ContainerConfig::create()
+                ->withProviders([$provider]),
+        );
+
+        $engine = $container->get(EngineMarkOne::class);
+        $engine->setNumber(42);
+        $container->get(StateResetter::class)->reset();
+
+        $engines = $container->get('tag@engine');
+
+        $this->assertSame(7, $engine->getNumber());
+        $this->assertIsArray($engines);
+        $this->assertSame($engine, $engines[0]);
+    }
+
     public function testNullableClassDependency(): void
     {
         $container = new Container();
@@ -729,6 +790,33 @@ final class ContainerTest extends TestCase
         } catch (CircularReferenceException) {
             $this->fail('Circular reference detected false positively.');
         }
+    }
+
+    public function testAddDefinitionWithMetadata(): void
+    {
+        $container = new Container();
+
+        (fn(string $id, $definition) => $this->addDefinition($id, $definition))->call(
+            $container,
+            EngineMarkOne::class,
+            [
+                'class' => EngineMarkOne::class,
+                'tags' => ['engine'],
+                'reset' => function (): void {
+                    $this->number = 7;
+                },
+            ],
+        );
+
+        $engine = $container->get(EngineMarkOne::class);
+        $engine->setNumber(42);
+        $container->get(StateResetter::class)->reset();
+
+        $engines = $container->get('tag@engine');
+
+        $this->assertSame(7, $engine->getNumber());
+        $this->assertIsArray($engines);
+        $this->assertSame($engine, $engines[0]);
     }
 
     public function testCallable(): void

--- a/tests/Unit/Helpers/DefinitionParserTest.php
+++ b/tests/Unit/Helpers/DefinitionParserTest.php
@@ -11,6 +11,14 @@ use Yiisoft\Di\Tests\Support\StaticFactory;
 
 final class DefinitionParserTest extends TestCase
 {
+    public function testParseNonArrayDefinition(): void
+    {
+        [$definition, $meta] = DefinitionParser::parse(EngineMarkOne::class);
+
+        $this->assertSame(EngineMarkOne::class, $definition);
+        $this->assertSame([], $meta);
+    }
+
     public function testParseCallableDefinition(): void
     {
         $fn = static fn() => new EngineMarkOne();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Performance optimizations. Overall results compared to `master`:

  | Benchmark | Set | master baseline | performance | Change |
  |---|---:|---:|---:|---:|
  | ContainerMethodHasBench::benchPredefinedExisting | - | 12.944μs | 9.339μs | -27.85% |
  | ContainerMethodHasBench::benchUndefinedExisting | - | 8.705μs | 4.888μs | -43.84% |
  | ContainerMethodHasBench::benchUndefinedNonexistent | - | 76.135μs | 4.806μs | -93.69% |
  | ContainerBench::benchConstruct | - | 46.537μs | 24.197μs | -48.01% |
  | ContainerBench::benchSequentialLookups | 0 | 97.115μs | 71.211μs | -26.67% |
  | ContainerBench::benchSequentialLookups | 1 | 101.089μs | 75.627μs | -25.19% |
  | ContainerBench::benchSequentialLookups | 2 | 103.364μs | 77.133μs | -25.38% |
  | ContainerBench::benchRandomLookups | 0 | 99.784μs | 71.519μs | -28.33% |
  | ContainerBench::benchRandomLookups | 1 | 103.061μs | 76.196μs | -26.07% |
  | ContainerBench::benchRandomLookups | 2 | 102.671μs | 77.168μs | -24.84% |
  | ContainerBench::benchRandomLookupsComposite | 0 | 388.613μs | 44.701μs | -88.50% |
  | ContainerBench::benchRandomLookupsComposite | 1 | 393.125μs | 45.335μs | -88.47% |
  | ContainerBench::benchRandomLookupsComposite | 2 | 393.340μs | 45.489μs | -88.44% |

What was done:

 - https://github.com/yiisoft/di/commit/f9b88a6cedbc39ddb9debac93121a73f600c6956: Cache Container::has() results and clear them when definitions change.
  - https://github.com/yiisoft/di/commit/f1e65683f05ab5857ca442800b0b04fcf89dcc57: Fast-return from validation for valid string definitions.
  - https://github.com/yiisoft/di/commit/63e5e2c9fde14069344f0c5f7504c7a7934bfaa5: Avoid duplicate has() before get() in build().
  - https://github.com/yiisoft/di/commit/a9818c385ac426fd115058cb515835013228dab2: Skip DefinitionParser::parse() for non-array definitions.
  - https://github.com/yiisoft/di/commit/10ec99d98aac7a16a649308c7977a338a145f062: Inline bulk addDefinitions() logic to reduce per-definition call overhead.
  - https://github.com/yiisoft/di/commit/c6dcb5c53f3e4e650426a4f8535e821451fe38d6: Batch-prepare initial definitions before constructing DefinitionStorage.
  - https://github.com/yiisoft/di/commit/a77213df05d3b20c68cc5e9c571efe275306ab50: Return early from delegate setup when no delegates are configured.
  - https://github.com/yiisoft/di/commit/423766a3a1f22c2df8c47684b37c149152c31d63: Split definition preparation into validated and no-validation branches.

There's a BC break because it makes a cache cap for `has()` configurable by adding it to the interface.